### PR TITLE
Ensure video modal stays hidden until opened

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -1967,6 +1967,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 padding: 20px;
             }
 
+            .video-modal[hidden] {
+                display: none !important;
+            }
+
             .video-modal-backdrop {
                 position: absolute;
                 inset: 0;
@@ -3112,6 +3116,16 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             const modalClose = document.querySelector('.video-modal-close');
             const modalBackdrop = document.querySelector('.video-modal-backdrop');
 
+            function closeModal() {
+                modal.hidden = true;
+                document.body.style.overflow = '';
+                modalVideo.pause();
+                modalVideo.currentTime = 0;
+            }
+
+            // Ensure modal starts off-screen
+            closeModal();
+
             // Filter functionality
             filterBtns.forEach(btn => {
                 btn.addEventListener('click', () => {
@@ -3156,13 +3170,6 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             });
 
             // Close modal functionality
-            function closeModal() {
-                modal.hidden = true;
-                document.body.style.overflow = '';
-                modalVideo.pause();
-                modalVideo.currentTime = 0;
-            }
-
             if (modalClose) modalClose.addEventListener('click', closeModal);
             if (modalBackdrop) modalBackdrop.addEventListener('click', closeModal);
             


### PR DESCRIPTION
## Summary
- add scoped hidden styling to the video modal to keep it off-screen by default
- initialize the modal state and reuse the shared close routine for all dismissal triggers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927e3056df0832db25d79040ec9fddc)

## Summary by Sourcery

Ensure the video modal is hidden off-screen by default and centralize its close behavior.

Enhancements:
- Hide the video modal via scoped CSS when the hidden attribute is set to prevent it from appearing before activation.
- Initialize the video modal in a closed state on page load using the shared close handler to standardize dismissal behavior.