### PR TITLE
Add YouTube feed teaser to video library

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -1733,6 +1733,119 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             }
 
             /* Video Library Gallery */
+            .youtube-latest {
+                margin: 8px auto 32px;
+                max-width: 980px;
+            }
+
+            .youtube-latest-header {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                margin-bottom: 10px;
+                color: var(--muted);
+                font-size: 13px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                font-weight: 700;
+            }
+
+            .youtube-latest-header svg {
+                color: var(--brand);
+            }
+
+            .youtube-latest-row {
+                display: flex;
+                gap: 12px;
+                overflow-x: auto;
+                padding: 6px 4px;
+                scroll-snap-type: x mandatory;
+            }
+
+            .youtube-latest-row::-webkit-scrollbar {
+                height: 8px;
+            }
+
+            .youtube-latest-row::-webkit-scrollbar-thumb {
+                background: rgba(20,40,72,.15);
+                border-radius: 999px;
+            }
+
+            .youtube-latest-card {
+                flex: 0 0 200px;
+                background: linear-gradient(180deg, #f8fafc 0%, #f1f4f9 100%);
+                border: 1px solid rgba(20,40,72,.08);
+                border-radius: 12px;
+                overflow: hidden;
+                text-decoration: none;
+                color: inherit;
+                box-shadow: 0 6px 16px rgba(20,40,72,.08);
+                transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+                scroll-snap-align: start;
+            }
+
+            .youtube-latest-card:hover {
+                transform: translateY(-4px);
+                box-shadow: 0 12px 24px rgba(20,40,72,.12);
+                border-color: rgba(255,77,0,.35);
+            }
+
+            .youtube-thumb {
+                position: relative;
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                background: linear-gradient(135deg, #142848 0%, #1a3a5f 100%);
+            }
+
+            .youtube-thumb img {
+                width: 100%;
+                height: 100%;
+                object-fit: cover;
+                display: block;
+            }
+
+            .youtube-thumb::after {
+                content: '';
+                position: absolute;
+                inset: 0;
+                background: linear-gradient(180deg, transparent 50%, rgba(0,0,0,.35) 100%);
+                pointer-events: none;
+            }
+
+            .youtube-meta {
+                padding: 10px 12px 12px;
+                display: grid;
+                gap: 6px;
+            }
+
+            .youtube-title {
+                font-weight: 700;
+                font-size: 14px;
+                line-height: 1.35;
+                color: var(--text);
+            }
+
+            .youtube-date {
+                font-size: 12px;
+                color: var(--muted);
+            }
+
+            .youtube-cta-card {
+                display: grid;
+                grid-template-rows: auto 1fr;
+                align-content: stretch;
+            }
+
+            .youtube-cta-card .youtube-meta {
+                gap: 8px;
+            }
+
+            .youtube-cta-note {
+                font-size: 13px;
+                color: var(--muted);
+                line-height: 1.5;
+            }
+
             .video-filters {
                 display: flex;
                 gap: 12px;
@@ -2354,6 +2467,31 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
         <section id="videos" class="container section">
             <div class="eyebrow">Learn & Explore</div>
             <h2><span class="hl">Video Library</span></h2>
+            <div class="youtube-latest">
+                <div class="youtube-latest-header">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814z" />
+                    </svg>
+                    <span>Latest from YouTube</span>
+                </div>
+                <div id="youtubeFeed" class="youtube-latest-row" data-channel-id="UC_x5XG1OV2P6uZZ5FSM9Ttw">
+                    <a id="youtubeSubscribeFallback" class="youtube-latest-card youtube-cta-card" href="https://www.youtube.com/@CerbiSuite" target="_blank" rel="noopener">
+                        <div class="youtube-thumb" aria-hidden="true">
+                            <img src="assets/CerbiLogo.png" alt="CerbiSuite logo" loading="lazy" decoding="async" />
+                        </div>
+                        <div class="youtube-meta">
+                            <div class="youtube-title">Subscribe on YouTube</div>
+                            <p class="youtube-cta-note">Catch new tutorials and product walk-throughs as soon as they drop.</p>
+                            <div style="display:flex;gap:8px;align-items:center;color:var(--brand);font-weight:700;font-size:13px;">
+                                <span>Open channel</span>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                    <path d="M14 3h7v7h-2V6.414l-9.293 9.293-1.414-1.414L17.586 5H14V3z" />
+                                </svg>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            </div>
             <p style="text-align:center;max-width:700px;margin:0 auto 1rem;color:var(--muted);font-size:15px">
                 Explore our complete collection of tutorials, demos, and insights. New videos added regularly.
             </p>
@@ -3099,6 +3237,76 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
                 grid.appendChild(node);
             });
+        })();
+
+        // YouTube feed teaser
+        (function () {
+            const feedContainer = document.getElementById('youtubeFeed');
+            if (!feedContainer) return;
+
+            const fallbackCard = document.getElementById('youtubeSubscribeFallback');
+            const channelId = (feedContainer.dataset.channelId || '').trim();
+            if (!channelId) return;
+
+            const feedUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${encodeURIComponent(channelId)}`;
+            const proxiedFeedUrl = `https://cors.isomorphic-git.org/${feedUrl}`;
+
+            const formatDate = (value) => {
+                try {
+                    return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(new Date(value));
+                } catch (_) {
+                    return '';
+                }
+            };
+
+            const buildCards = (xmlDoc) => {
+                const entries = Array.from(xmlDoc.querySelectorAll('entry')).slice(0, 4);
+                if (!entries.length) return false;
+
+                feedContainer.innerHTML = '';
+                entries.forEach(entry => {
+                    const link = entry.querySelector('link')?.getAttribute('href');
+                    if (!link) return;
+
+                    const title = entry.querySelector('title')?.textContent?.trim() || 'Watch on YouTube';
+                    const published = entry.querySelector('published')?.textContent;
+                    const thumbEl = entry.getElementsByTagNameNS('http://search.yahoo.com/mrss/', 'thumbnail')[0] || entry.getElementsByTagName('media:thumbnail')[0];
+                    const thumb = thumbEl?.getAttribute('url');
+
+                    const card = document.createElement('a');
+                    card.className = 'youtube-latest-card';
+                    card.href = link;
+                    card.target = '_blank';
+                    card.rel = 'noopener';
+                    card.innerHTML = `
+                        <div class="youtube-thumb">${thumb ? `<img src="${thumb}" alt="${title}" loading="lazy" decoding="async" />` : ''}</div>
+                        <div class="youtube-meta">
+                            <div class="youtube-title">${title}</div>
+                            <div class="youtube-date">${formatDate(published) || 'Latest release'}</div>
+                        </div>
+                    `;
+                    feedContainer.appendChild(card);
+                });
+
+                if (feedContainer.children.length === 0) return false;
+                if (fallbackCard) fallbackCard.hidden = true;
+                return true;
+            };
+
+            const fetchFeed = (url) => fetch(url, { cache: 'no-store' }).then(res => {
+                if (!res.ok) throw new Error('Feed fetch failed');
+                return res.text();
+            }).then(xmlText => {
+                const xml = new DOMParser().parseFromString(xmlText, 'text/xml');
+                if (xml.querySelector('parsererror')) throw new Error('Parse error');
+                if (!buildCards(xml)) throw new Error('No entries rendered');
+            });
+
+            fetchFeed(feedUrl)
+                .catch(() => fetchFeed(proxiedFeedUrl))
+                .catch(err => {
+                    console.warn('YouTube feed unavailable; showing subscribe CTA.', err);
+                });
         })();
 
         // Video Library functionality


### PR DESCRIPTION
## Summary
- add a subdued "Latest from YouTube" strip beneath the Video Library heading
- fetch and render recent entries from the channel RSS feed with a fallback subscribe CTA
- introduce lightweight styling for the horizontal thumbnail cards and feed row

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927e343d980832d9e51eddd62e6ef01)

## Summary by Sourcery

Add a YouTube "Latest from YouTube" teaser strip to the Video Library section that surfaces recent channel videos with a styled horizontal card row and a graceful subscribe fallback when the feed is unavailable.

New Features:
- Introduce a horizontally scrollable "Latest from YouTube" teaser row beneath the Video Library heading, showing recent channel videos as thumbnail cards sourced from the YouTube RSS feed.
- Provide a subscribe CTA card as a visual fallback when the YouTube feed cannot be loaded.

Enhancements:
- Add styling for YouTube teaser cards, thumbnails, metadata, and scroll behavior to integrate the feed row with the existing Video Library layout.