### PR TITLE
Tighten architecture image and logo sizing

### DIFF
--- a/cerbi-theme.css
+++ b/cerbi-theme.css
@@ -372,7 +372,7 @@ body.scrolled .ribbon{ transform: translateY(calc(-1 * var(--ribbon-h))); }
   border-radius:16px; border:1px solid rgba(127,148,179,.25); overflow:hidden;
   background: radial-gradient(120% 100% at 100% 0%, rgba(100,160,255,.12), transparent 60%), rgba(12,17,24,.55);
 }
-.img-frame img{ width:100%; height:100%; object-fit:cover; object-position:center; display:block }
+.img-frame img{ width:100%; height:auto; max-height:100%; object-fit:contain; object-position:center; display:block }
 .img-cap{font-size:12px;color:var(--muted);margin-top:8px;text-align:center}
 :root[data-theme="light"] .img-frame{ border-color:var(--glass-border); background: radial-gradient(120% 100% at 100% 0%, rgba(16,24,40,.06), transparent 60%), #fff }
 

--- a/index.html
+++ b/index.html
@@ -526,7 +526,7 @@
         .arch-diagram img {
             width: 100%;
             height: auto;
-            max-height: 520px;
+            max-height: 420px;
             object-fit: contain;
             border-radius: 12px;
             border: 1px solid rgba(20,40,72,.12)


### PR DESCRIPTION
## Summary
- reduce the reference architecture figure max height for better balance
- change generic image-frame styling to maintain aspect ratio and prevent logo distortion

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927f2dc930c832d86c62b4c477ee753)

## Summary by Sourcery

Adjust image styling to improve layout balance and prevent logo distortion.

Enhancements:
- Reduce the maximum height of the architecture diagram image for better visual balance.
- Update generic image frame styling to preserve aspect ratios and avoid stretching logos or other images.