### PR TITLE
Improve stat readability and stabilize NuGet cards

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -95,11 +95,16 @@
 
         .stat-label {
             font-size: clamp(12px, 1.2vw, 14px);
-            color: #0b1324;
-            font-weight: 600;
+            color: var(--text-strong);
+            font-weight: 700;
             text-transform: uppercase;
             letter-spacing: 0.5px;
-            text-shadow: 0 1px 6px rgba(255,255,255,.7);
+            text-shadow: none;
+            background: rgba(255, 255, 255, 0.8);
+            display: inline-block;
+            padding: 6px 10px;
+            border-radius: 999px;
+            border: 1px solid rgba(20,40,72,.1);
         }
 
         /* Hero CTAs */
@@ -1476,21 +1481,23 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             }
 
             /* NuGet Flip Cards */
-            .nuget-flip-card {
-                background: transparent;
-                perspective: 1000px;
-                cursor: pointer;
-                min-height: 380px;
-            }
+        .nuget-flip-card {
+            background: transparent;
+            perspective: 1000px;
+            cursor: pointer;
+            min-height: 380px;
+            position: relative;
+        }
 
-            .nuget-flip-inner {
-                position: relative;
-                width: 100%;
-                height: 100%;
-                text-align: center;
-                transition: transform 0.6s cubic-bezier(0.4, 0.2, 0.2, 1);
-                transform-style: preserve-3d;
-            }
+        .nuget-flip-inner {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            text-align: center;
+            transition: transform 0.6s cubic-bezier(0.4, 0.2, 0.2, 1);
+            transform-style: preserve-3d;
+            will-change: transform;
+        }
 
             .nuget-flip-card.flipped .nuget-flip-inner {
                 transform: rotateY(180deg);
@@ -1517,11 +1524,21 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 transition: all .3s ease;
             }
 
-            .nuget-flip-card:hover .nuget-flip-front {
-                border-color: var(--brand);
-                box-shadow: 0 8px 24px rgba(255,77,0,.15);
-                transform: translateY(-4px);
-            }
+        .nuget-flip-card:not(.flipped):hover .nuget-flip-front {
+            border-color: var(--brand);
+            box-shadow: 0 8px 24px rgba(255,77,0,.15);
+            transform: translateY(-4px);
+        }
+
+        .nuget-flip-card.flipped .nuget-flip-front {
+            transform: none;
+            pointer-events: none;
+            box-shadow: 0 4px 12px rgba(20,40,72,.08);
+        }
+
+        .nuget-flip-card.flipped {
+            cursor: default;
+        }
 
             .nuget-flip-back {
                 background: linear-gradient(135deg, #142848 0%, #1a3a5f 100%);
@@ -2472,7 +2489,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
                         </svg>
                     </button>
-                    <div id="youtubeFeed" class="youtube-latest-row" data-channel-handle="@cerbihello"></div>
+                    <div id="youtubeFeed" class="youtube-latest-row" data-channel-handle="@CerbiSuite"></div>
                     <button class="youtube-nav" type="button" aria-label="Next video" data-dir="1">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                             <path d="m10 6-1.41 1.41L13.17 12l-4.58 4.59L10 18l6-6z" />
@@ -3280,6 +3297,27 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             const sliderShell = feedContainer.closest('.youtube-slider-shell');
             const navButtons = sliderShell ? sliderShell.querySelectorAll('.youtube-nav') : [];
 
+            const fallbackVideos = [
+                {
+                    title: 'CerbiStream — Demo Overview',
+                    url: 'https://www.youtube.com/@CerbiSuite/videos',
+                    date: 'Watch on YouTube',
+                    thumb: 'assets/CerbiShield.png'
+                },
+                {
+                    title: 'Cerbi Governance — Build + Runtime',
+                    url: 'https://www.youtube.com/@CerbiSuite/videos',
+                    date: 'Compliance in minutes',
+                    thumb: 'assets/CerbiLogo.png'
+                },
+                {
+                    title: 'Telemetry that ML can trust',
+                    url: 'https://www.youtube.com/@CerbiSuite/videos',
+                    date: 'Structured + redacted',
+                    thumb: 'assets/CerbiStream.png'
+                }
+            ];
+
             const handle = (feedContainer.dataset.channelHandle || '').replace(/^@/, '');
             const presetChannelId = (feedContainer.dataset.channelId || '').trim();
 
@@ -3343,6 +3381,26 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 return feedContainer.children.length > 0;
             };
 
+            const renderFallback = () => {
+                feedContainer.innerHTML = '';
+                fallbackVideos.forEach(video => {
+                    const card = document.createElement('a');
+                    card.className = 'youtube-latest-card';
+                    card.href = video.url;
+                    card.target = '_blank';
+                    card.rel = 'noopener';
+                    card.innerHTML = `
+                        <div class="youtube-thumb">${video.thumb ? `<img src="${video.thumb}" alt="${video.title}" loading="lazy" decoding="async" />` : ''}</div>
+                        <div class="youtube-meta">
+                            <div class="youtube-title">${video.title}</div>
+                            <div class="youtube-date">${video.date}</div>
+                        </div>
+                    `;
+                    feedContainer.appendChild(card);
+                });
+                return feedContainer.children.length > 0;
+            };
+
             const fetchFeed = (url) => fetch(url, { cache: 'no-store' }).then(res => {
                 if (!res.ok) throw new Error('Feed fetch failed');
                 return res.text();
@@ -3371,7 +3429,11 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
             const hydrateFeed = async () => {
                 const channelId = await resolveChannelId();
-                if (!channelId) return;
+                if (!channelId) {
+                    renderFallback();
+                    initSliderNav();
+                    return;
+                }
 
                 const feedUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${encodeURIComponent(channelId)}`;
                 const proxiedFeedUrl = `https://cors.isomorphic-git.org/${feedUrl}`;
@@ -3381,6 +3443,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     .then(initSliderNav)
                     .catch(err => {
                         console.warn('YouTube feed unavailable; skipping slider.', err);
+                        if (!feedContainer.children.length) {
+                            renderFallback();
+                            initSliderNav();
+                        }
                     });
             };
 


### PR DESCRIPTION
## Summary
- improve hero KPI readability with darker text and pill styling
- reduce NuGet flip-card jitter by refining hover behavior and pointer handling
- correct YouTube feed handle and add fallback cards when the feed is unavailable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928003d5128832db5c8c680c4726e4f)

## Summary by Sourcery

Improve hero stat readability, stabilize NuGet flip-card interactions, and make the YouTube video section more resilient when the feed is unavailable.

New Features:
- Add static fallback YouTube video cards when the live channel feed cannot be resolved or loaded.

Enhancements:
- Increase hero stat label contrast and introduce pill-style styling for better visual clarity.
- Refine NuGet flip-card hover and flipped-state behavior to reduce jitter and unintended interactions.
- Update the YouTube channel handle used for the video feed to the current CerbiSuite channel.