### PR TITLE
Add YouTube channel section highlighting story video

### DIFF
--- a/index.html
+++ b/index.html
@@ -1019,6 +1019,22 @@
             </div>
         </section>
 
+        <section id="youtube-channel" class="container section">
+            <div class="eyebrow">Watch more</div>
+            <h2>Cerbi on YouTube</h2>
+            <p class="lead">Explore the full playlist of Cerbi videos on our YouTube channel—start with <strong>The Story of Cerbi</strong> for the big picture.</p>
+            <div class="card" style="padding:18px;display:flex;flex-wrap:wrap;gap:16px;align-items:center;justify-content:space-between;row-gap:10px;">
+                <div style="flex:1 1 320px;min-width:260px;">
+                    <h3 style="margin-top:0;margin-bottom:8px;">Top pick: The Story of Cerbi</h3>
+                    <p class="muted" style="margin:0;">Learn why Cerbi was created, the problems it solves, and how it fits into your governance and observability strategy.</p>
+                </div>
+                <div style="display:flex;gap:10px;flex-wrap:wrap;flex:0 0 auto;">
+                    <a class="btn" style="text-decoration:none;" href="https://www.youtube.com/@cerbihello" target="_blank" rel="noreferrer noopener">Visit the YouTube channel</a>
+                    <a class="btn btn-ghost" style="text-decoration:none;" href="https://www.youtube.com/@cerbihello/videos" target="_blank" rel="noreferrer noopener">Watch “The Story of Cerbi”</a>
+                </div>
+            </div>
+        </section>
+
         <section id="quickstart" class="container section">
             <div class="eyebrow">Get started</div>
             <h2>⚡ <span class="hl">Quick Start</span>: Try <span class="hl">CerbiStream</span> in 60 Seconds</h2>


### PR DESCRIPTION
## Summary
- add a YouTube call-to-action section to highlight the Cerbi channel and emphasize the Story of Cerbi video
- include quick links to the channel home and videos list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692803079600832dbe4f981487c307f4)

## Summary by Sourcery

New Features:
- Introduce a dedicated YouTube section featuring the Cerbi channel and Story of Cerbi video with direct external links.