### PR TITLE
Update YouTube links to cerbihello channel

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -2499,7 +2499,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
                         </svg>
                     </button>
-                    <div id="youtubeFeed" class="youtube-latest-row" data-channel-handle="@CerbiSuite"></div>
+                    <div id="youtubeFeed" class="youtube-latest-row" data-channel-handle="@cerbihello"></div>
                     <button class="youtube-nav" type="button" aria-label="Next video" data-dir="1">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                             <path d="m10 6-1.41 1.41L13.17 12l-4.58 4.59L10 18l6-6z" />
@@ -2615,7 +2615,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 </article>
 
                 <!-- Video Card 5: YouTube Playlist -->
-                <article class="video-card" data-category="overview" data-duration="YouTube" data-url="https://www.youtube.com/@CerbiSuite/videos">
+                <article class="video-card" data-category="overview" data-duration="YouTube" data-url="https://www.youtube.com/@cerbihello/videos">
                     <div class="video-thumbnail placeholder-thumb">
                         <div class="placeholder-icon">
                             <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -2859,7 +2859,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <div>
                     <h4 style="margin:0 0 16px;font-size:15px;font-weight:600;color:var(--text-strong)">Connect</h4>
                     <div style="display:flex;flex-direction:column;gap:8px">
-                        <a class="chip" href="https://www.youtube.com/@CerbiSuite" target="_blank" rel="noopener" style="width:fit-content">
+                        <a class="chip" href="https://www.youtube.com/@cerbihello" target="_blank" rel="noopener" style="width:fit-content">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:-2px;margin-right:4px">
                                 <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
                             </svg>
@@ -2895,7 +2895,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
                         </svg>
                     </a>
-                    <a href="https://www.youtube.com/@CerbiSuite" target="_blank" rel="noopener" aria-label="YouTube" style="color:var(--muted);transition:color .2s">
+                    <a href="https://www.youtube.com/@cerbihello" target="_blank" rel="noopener" aria-label="YouTube" style="color:var(--muted);transition:color .2s">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
                         </svg>
@@ -3330,19 +3330,19 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             const fallbackVideos = [
                 {
                     title: 'CerbiStream — Demo Overview',
-                    url: 'https://www.youtube.com/@CerbiSuite/videos',
+                    url: 'https://www.youtube.com/@cerbihello/videos',
                     date: 'Watch on YouTube',
                     thumb: 'assets/CerbiShield.png'
                 },
                 {
                     title: 'Cerbi Governance — Build + Runtime',
-                    url: 'https://www.youtube.com/@CerbiSuite/videos',
+                    url: 'https://www.youtube.com/@cerbihello/videos',
                     date: 'Compliance in minutes',
                     thumb: 'assets/CerbiLogo.png'
                 },
                 {
                     title: 'Telemetry that ML can trust',
-                    url: 'https://www.youtube.com/@CerbiSuite/videos',
+                    url: 'https://www.youtube.com/@cerbihello/videos',
                     date: 'Structured + redacted',
                     thumb: 'assets/CerbiStream.png'
                 }


### PR DESCRIPTION
## Summary
- point all YouTube links in the video gallery to the cerbihello channel handle
- ensure the latest videos feed pulls from the correct channel

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692899375420832d807fdf44b86ab04a)

## Summary by Sourcery

Enhancements:
- Retarget the latest videos feed, video gallery playlist card, footer links, and fallback video URLs from the old CerbiSuite YouTube handle to the cerbihello channel handle.