### PR TITLE
Update YouTube slider fallback videos

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -3329,22 +3329,34 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
             const fallbackVideos = [
                 {
-                    title: 'CerbiStream — Demo Overview',
-                    url: 'https://www.youtube.com/@cerbihello/videos',
+                    title: 'The Story of Cerbi',
+                    url: 'https://www.youtube.com/watch?v=4YsEgMs2Xs4',
                     date: 'Watch on YouTube',
-                    thumb: 'assets/CerbiShield.png'
+                    thumb: 'https://img.youtube.com/vi/4YsEgMs2Xs4/hqdefault.jpg'
                 },
                 {
-                    title: 'Cerbi Governance — Build + Runtime',
-                    url: 'https://www.youtube.com/@cerbihello/videos',
-                    date: 'Compliance in minutes',
-                    thumb: 'assets/CerbiLogo.png'
+                    title: 'Cerbi PII Safe Logging — now with Scoring',
+                    url: 'https://www.youtube.com/watch?v=zq0ALa0-IBA',
+                    date: 'Watch on YouTube',
+                    thumb: 'https://img.youtube.com/vi/zq0ALa0-IBA/hqdefault.jpg'
                 },
                 {
-                    title: 'Telemetry that ML can trust',
-                    url: 'https://www.youtube.com/@cerbihello/videos',
-                    date: 'Structured + redacted',
-                    thumb: 'assets/CerbiStream.png'
+                    title: 'Cerbi: A Brief Overview',
+                    url: 'https://www.youtube.com/watch?v=JAUk8hr6fkY',
+                    date: 'Watch on YouTube',
+                    thumb: 'https://img.youtube.com/vi/JAUk8hr6fkY/hqdefault.jpg'
+                },
+                {
+                    title: 'CerbiStream Demo Overview',
+                    url: 'https://www.youtube.com/watch?v=M3ErdPnub4k&t=5s',
+                    date: 'Watch on YouTube',
+                    thumb: 'https://img.youtube.com/vi/M3ErdPnub4k/hqdefault.jpg'
+                },
+                {
+                    title: 'CerbiSuite: Governed Logging — Shift Left',
+                    url: 'https://www.youtube.com/watch?v=Jta9BnkrKQU&t=3s',
+                    date: 'Watch on YouTube',
+                    thumb: 'https://img.youtube.com/vi/Jta9BnkrKQU/hqdefault.jpg'
                 }
             ];
 


### PR DESCRIPTION
## Summary
- update the YouTube slider fallback to feature key Cerbi videos with thumbnails
- ensure links point directly to the requested YouTube videos for quick access

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69289b076648832d9adf019b60f6fbfc)

## Summary by Sourcery

Update the YouTube slider fallback content to feature specific Cerbi videos with direct links and thumbnails.

New Features:
- Add additional Cerbi video entries to the YouTube slider fallback list.

Enhancements:
- Replace generic channel links and local placeholder thumbnails in the YouTube slider fallback with direct video URLs and corresponding YouTube thumbnail images.