### PR TITLE
Rotate hero backgrounds on each page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -3299,9 +3299,11 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 'assets/screenshots/cerbishield-hero-1600x900.jpg'
             ];
             const candidates = numbered.concat(extras);
-            const stored = sessionStorage.getItem('cerbi-bg');
-            const start = Math.floor(Math.random() * candidates.length);
-            const rotated = (stored ? [stored] : []).concat(candidates.slice(start), candidates.slice(0, start), fallbacks);
+            const lastBg = sessionStorage.getItem('cerbi-bg');
+            const lastIndex = lastBg ? candidates.indexOf(lastBg) : -1;
+            const randomStart = Math.floor(Math.random() * candidates.length);
+            const nextIndex = lastIndex >= 0 ? (lastIndex + 1) % candidates.length : randomStart;
+            const rotated = candidates.slice(nextIndex).concat(candidates.slice(0, nextIndex), fallbacks);
 
             function setBg(u) {
                 document.documentElement.style.setProperty('--bg-url', `url('${u}')`);


### PR DESCRIPTION
## Summary
- advance rotating background images on each page load instead of reusing the stored value
- preserve existing fallback images while updating selection logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69289ead7f00832d8876fa0e1e927620)

## Summary by Sourcery

Enhancements:
- Track and advance the last-used hero background image across page loads instead of reusing the same stored value.