### PR TITLE
Refactor hero metrics into animated cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Roboto+Mono:wght@400;600&display=swap" rel="stylesheet">
     <!-- Swiper CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
 
     <style>
         :root {
@@ -66,59 +68,132 @@
         .container { width: var(--container); margin-inline: auto }
         .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0 }
 
-        /* Hero Stats Banner */
-        .stats-banner {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-            gap: clamp(18px, 3vw, 28px);
-            justify-content: center;
-            align-items: stretch;
+        /* Hero Metrics */
+        .metrics-shell {
             margin: 40px auto 32px;
-            padding: clamp(24px, 4vw, 36px);
-            background: linear-gradient(135deg, rgba(255,77,0,.12) 0%, rgba(15,99,255,.12) 100%);
-            border-radius: 18px;
-            border: 1px solid rgba(255,77,0,.18);
-            max-width: 980px;
+            max-width: 1080px;
+            background: linear-gradient(135deg, rgba(255,77,0,.1) 0%, rgba(15,99,255,.12) 100%);
+            border-radius: 22px;
+            padding: clamp(22px, 4vw, 38px);
+            border: 1px solid color-mix(in srgb, var(--brand) 32%, transparent);
             box-shadow: 0 18px 40px rgba(12, 22, 44, 0.12);
         }
 
-        .stat-item {
-            text-align: center;
-            background: rgba(255, 255, 255, 0.82);
-            border-radius: 14px;
-            padding: clamp(14px, 2.2vw, 20px);
-            border: 1px solid rgba(24, 34, 53, 0.08);
+        .metrics-grid {
             display: grid;
-            gap: 8px;
-            align-content: center;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: clamp(18px, 3vw, 24px);
         }
 
-        .stat-number {
-            font-size: clamp(38px, 5.8vw, 60px);
+        .metric-card {
+            background: rgba(255, 255, 255, 0.9);
+            border-radius: 16px;
+            padding: clamp(16px, 2.4vw, 22px);
+            border: 1px solid rgba(24, 34, 53, 0.12);
+            display: grid;
+            gap: 8px;
+            align-content: start;
+            transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+            will-change: transform;
+            box-shadow: 0 8px 20px rgba(12, 22, 44, 0.08);
+        }
+
+        .metric-card:hover,
+        .metric-card:focus-within {
+            transform: translateY(-3px) scale(1.02);
+            box-shadow: 0 14px 30px rgba(12, 22, 44, 0.14);
+            border-color: color-mix(in srgb, var(--brand) 32%, rgba(24,34,53,.12));
+        }
+
+        .metric-number {
+            font-size: clamp(42px, 5.8vw, 64px);
             font-weight: 800;
             color: var(--brand);
             line-height: 1;
-            margin-bottom: 4px;
+            margin-bottom: 6px;
+            letter-spacing: -0.5px;
+            font-variant-numeric: tabular-nums;
+            min-height: 56px;
         }
 
-        .stat-label {
-            font-size: clamp(14px, 1.4vw, 16px);
+        .metric-label {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: clamp(15px, 1.5vw, 17px);
             color: var(--text-strong);
             font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.4px;
-            text-shadow: none;
-            background: rgba(24, 34, 53, 0.08);
-            display: inline-block;
-            padding: 8px 12px;
-            border-radius: 999px;
-            border: 1px solid rgba(24,34,53,.18);
+            letter-spacing: 0.2px;
         }
 
-        .stat-note {
+        .metric-note {
             font-size: clamp(13px, 1.2vw, 15px);
             color: var(--muted);
-            line-height: 1.4;
+            line-height: 1.5;
+            margin: 0;
+        }
+
+        .info-trigger {
+            appearance: none;
+            background: color-mix(in srgb, var(--brand) 12%, white 88%);
+            border: 1px solid color-mix(in srgb, var(--brand) 30%, rgba(24,34,53,.14));
+            color: var(--brand);
+            border-radius: 50%;
+            width: 26px;
+            height: 26px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 800;
+            cursor: help;
+            transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+        }
+
+        .info-trigger:hover,
+        .info-trigger:focus-visible {
+            transform: translateY(-1px);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 25%, white 75%);
+            outline: none;
+            background: color-mix(in srgb, var(--brand) 16%, white 84%);
+        }
+
+        .tooltip-bubble {
+            position: absolute;
+            inset-inline-start: 0;
+            top: calc(100% + 8px);
+            min-width: 220px;
+            max-width: 320px;
+            padding: 10px 12px;
+            background: #0b1324;
+            color: #f8fafc;
+            border-radius: 10px;
+            box-shadow: 0 14px 34px rgba(12,22,44,0.32);
+            font-size: 13px;
+            line-height: 1.45;
+            z-index: 4;
+        }
+
+        .tooltip-bubble::after {
+            content: "";
+            position: absolute;
+            top: -6px;
+            inset-inline-start: 12px;
+            border-width: 6px;
+            border-style: solid;
+            border-color: transparent transparent #0b1324 transparent;
+        }
+
+        .tooltip-wrapper {
+            position: relative;
+            display: inline-flex;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .metric-card,
+            .info-trigger {
+                transition: none;
+                transform: none !important;
+            }
         }
 
         /* Hero CTAs */
@@ -674,21 +749,23 @@
             <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Enterprise .NET logging with built-in governance. Deploy in hours, not months. Turn your logs into compliant, ML-ready assets.</p>
 
             <!-- Executive Stats Banner -->
-            <div class="stats-banner">
-                <div class="stat-item">
-                    <div class="stat-number">40%</div>
-                    <div class="stat-label">Log spend eliminated</div>
-                    <div class="stat-note">In the first 90 days of rollout.</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-number">95%</div>
-                    <div class="stat-label">Compliance pass rate</div>
-                    <div class="stat-note">On first audit with Cerbi controls.</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-number">3x</div>
-                    <div class="stat-label">Faster incident response</div>
-                    <div class="stat-note">After instrumenting runbooks end-to-end.</div>
+            <div id="heroMetrics" class="metrics-shell">
+                <div class="metrics-grid">
+                    <article class="metric-card">
+                        <div class="metric-number">40%</div>
+                        <div class="metric-label">Log spend eliminated</div>
+                        <p class="metric-note">In the first 90 days of rollout.</p>
+                    </article>
+                    <article class="metric-card">
+                        <div class="metric-number">95%</div>
+                        <div class="metric-label">Compliance pass rate</div>
+                        <p class="metric-note">On first audit with Cerbi controls.</p>
+                    </article>
+                    <article class="metric-card">
+                        <div class="metric-number">3x</div>
+                        <div class="metric-label">Faster incident response</div>
+                        <p class="metric-note">After instrumenting runbooks end-to-end.</p>
+                    </article>
                 </div>
             </div>
 
@@ -2946,6 +3023,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
     <!-- Swiper JS -->
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
+    <script src="scripts/hero-metrics.js"></script>
 
     <script>
         // Year in footer

--- a/scripts/hero-metrics.js
+++ b/scripts/hero-metrics.js
@@ -1,0 +1,164 @@
+(function () {
+    const root = document.getElementById('heroMetrics');
+    if (!root || !window.React || !window.ReactDOM) return;
+
+    const { useEffect, useRef, useState } = React;
+    const h = React.createElement;
+
+    const metrics = [
+        {
+            id: 'log-cost',
+            value: 40,
+            suffix: '%',
+            label: 'Log spend eliminated',
+            note: 'In the first 90 days of rollout.',
+            tooltip: 'Based on teams reducing redundant log sinks and lowering ingestion volume with Cerbi rules.',
+            start: 0,
+        },
+        {
+            id: 'compliance',
+            value: 95,
+            suffix: '%',
+            label: 'Compliance pass rate',
+            note: 'On first audit with Cerbi controls.',
+            tooltip: 'Driven by automated control mapping, evidence capture, and scoped audit views.',
+            start: 0,
+        },
+        {
+            id: 'incidents',
+            value: 3,
+            suffix: 'x',
+            label: 'Faster incident response',
+            note: 'After instrumenting runbooks end-to-end.',
+            tooltip: 'Teams speed up containment by codifying incident runbooks and guardrails directly into logging flows.',
+            start: 1,
+        }
+    ];
+
+    function useInView(ref, threshold = 0.35) {
+        const [inView, setInView] = useState(false);
+
+        useEffect(() => {
+            const node = ref.current;
+            if (!node || inView) return;
+
+            if (!('IntersectionObserver' in window)) {
+                setInView(true);
+                return;
+            }
+
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        setInView(true);
+                        observer.disconnect();
+                    }
+                });
+            }, { threshold });
+
+            observer.observe(node);
+            return () => observer.disconnect();
+        }, [inView, ref, threshold]);
+
+        return inView;
+    }
+
+    function useCountUp({ target, start = 0, duration = 900, shouldStart }) {
+        const [value, setValue] = useState(target);
+        const hasAnimated = useRef(false);
+
+        useEffect(() => {
+            if (!shouldStart || hasAnimated.current) return;
+            const prefersReducedMotion = typeof window !== 'undefined'
+                && window.matchMedia
+                && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+            if (prefersReducedMotion) {
+                setValue(target);
+                hasAnimated.current = true;
+                return;
+            }
+
+            hasAnimated.current = true;
+
+            let raf;
+            const startTime = performance.now();
+
+            const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+            setValue(start);
+
+            const step = (now) => {
+                const progress = Math.min((now - startTime) / duration, 1);
+                const next = start + (target - start) * easeOut(progress);
+                setValue(next);
+                if (progress < 1) raf = requestAnimationFrame(step);
+            };
+
+            raf = requestAnimationFrame(step);
+            return () => cancelAnimationFrame(raf);
+        }, [duration, shouldStart, start, target]);
+
+        return value;
+    }
+
+    function formatValue(value, suffix) {
+        const rounded = suffix === 'x' ? value.toFixed(1).replace(/\.0$/, '') : Math.round(value).toString();
+        return `${rounded}${suffix || ''}`;
+    }
+
+    function Tooltip({ id, content, onClose }) {
+        const [open, setOpen] = useState(false);
+        const bubbleId = `${id}-tooltip`;
+
+        const show = () => setOpen(true);
+        const hide = () => { setOpen(false); onClose?.(); };
+
+        return h('span', { className: 'tooltip-wrapper' },
+            h('button', {
+                type: 'button',
+                className: 'info-trigger',
+                'aria-label': 'More info',
+                'aria-describedby': open ? bubbleId : undefined,
+                onMouseEnter: show,
+                onMouseLeave: hide,
+                onFocus: show,
+                onBlur: hide,
+                onKeyDown: (e) => { if (e.key === 'Escape') hide(); }
+            }, 'ⓘ'),
+            open && h('span', {
+                role: 'tooltip',
+                id: bubbleId,
+                className: 'tooltip-bubble'
+            }, content)
+        );
+    }
+
+    function MetricCard({ metric }) {
+        const cardRef = useRef(null);
+        const inView = useInView(cardRef);
+        const animatedValue = useCountUp({
+            target: metric.value,
+            start: metric.start ?? 0,
+            duration: 900,
+            shouldStart: inView,
+        });
+
+        const displayValue = inView ? animatedValue : metric.value;
+
+        return h('article', { className: 'metric-card', ref: cardRef, tabIndex: 0 },
+            h('div', { className: 'metric-number', 'aria-live': 'polite', 'data-final': formatValue(metric.value, metric.suffix) }, formatValue(displayValue, metric.suffix)),
+            h('div', { className: 'metric-label' },
+                metric.label,
+                metric.tooltip ? h(Tooltip, { id: metric.id, content: metric.tooltip }) : null
+            ),
+            h('p', { className: 'metric-note' }, metric.note)
+        );
+    }
+
+    const Metrics = () => h('div', { className: 'metrics-grid' }, metrics.map((metric) =>
+        h(MetricCard, { key: metric.id, metric })
+    ));
+
+    const rootNode = ReactDOM.createRoot(root);
+    rootNode.render(h(Metrics));
+})();


### PR DESCRIPTION
## Summary
- replace the hero stats banner with a card-based layout that keeps the existing copy
- add a lightweight React component with in-view count-up animation and accessible tooltip support
- introduce styling for hover/focus micro-interactions to give the metrics a premium feel

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692940e2428c832dac89e92c741b2b27)

## Summary by Sourcery

Refactor the hero stats banner into a React-powered metrics section with animated cards and accessible tooltips.

New Features:
- Introduce a React-based hero metrics component with in-view count-up animations for key statistics.
- Add accessible tooltip support to provide additional context for each hero metric.

Enhancements:
- Restyle the hero metrics into card-based layout with hover and focus micro-interactions for a more premium feel.

Build:
- Load React and ReactDOM from a CDN and include a dedicated script for the hero metrics component.