### PR TITLE
Improve mobile responsiveness for showcase sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
             text-rendering: optimizeLegibility;
             line-height: 1.55;
             padding-top: var(--nav-h);
+            overflow-x: hidden;
         }
         a { color: var(--link); text-decoration: none }
         a:hover { text-decoration: underline }
@@ -560,6 +561,11 @@
             .flow-details { width: 90vw; left: 50vw; transform: translateX(-50%); }
         }
 
+        @media (max-width:480px) {
+            .flow-node { width: 100%; }
+            .flow-details { width: 92vw; }
+        }
+
         /* Swiper styles */
         .full-bleed-wrap { position: relative; left: 50%; right: 50%; margin-left: -50vw; margin-right: -50vw; width: 100vw; }
         .showcase { padding: 2rem 0 1rem; }
@@ -576,6 +582,51 @@
         @media (min-width: 900px) { .sig-rotator { min-height: clamp(360px, 56vw, 525px); } }
         .sig-rotator img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; opacity: 0; visibility: hidden; transform: scale(1.02); transition: opacity .45s ease, visibility .45s ease, transform .6s ease }
         .sig-rotator img.is-active { opacity: 1; visibility: visible; transform: none }
+
+        @media (max-width: 820px) {
+            .full-bleed-wrap {
+                left: auto;
+                right: auto;
+                margin-left: 0;
+                margin-right: 0;
+                width: 100%;
+            }
+
+            .showcase-outer {
+                width: 100% !important;
+                margin-left: 0 !important;
+                transform: none !important;
+                padding-inline: 14px;
+                box-sizing: border-box;
+            }
+
+            #dashboards .mySwiper {
+                width: 100%;
+                padding-inline: 6px;
+                box-sizing: border-box;
+            }
+
+            .swiper-slide {
+                width: 100%;
+            }
+
+            .swiper-button-next,
+            .swiper-button-prev {
+                display: none;
+            }
+
+            .img-cap {
+                padding-inline: 10px;
+            }
+
+            .sig-outer {
+                width: 100%;
+                margin-left: 0;
+                transform: none;
+                padding-inline: 14px;
+                box-sizing: border-box;
+            }
+        }
 
         #nugetGrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 24px; }
         #nugetGrid .card { display: flex; flex-direction: column }


### PR DESCRIPTION
## Summary
- Prevent horizontal overflow on small screens and allow dashboards/signature sections to respect mobile viewports.
- Hide desktop-only swiper arrows on mobile while padding the slider/captions for touch devices.
- Stack governance flow nodes cleanly on very small screens for better readability.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692942d62240832da170f736021d9c5b)

## Summary by Sourcery

Improve mobile responsiveness and layout of showcase and governance sections across small viewports.

Enhancements:
- Prevent horizontal overflow on the main page container to avoid sideways scrolling on small screens.
- Adjust governance flow node and details widths on very small screens to stack and fit within the viewport.
- Make full-bleed showcase, dashboard swiper, and signature sections adapt to mobile widths with appropriate padding and box sizing.
- Hide swiper navigation arrows on mobile while ensuring slides and captions span the full available width.