### PR TITLE
Fix metric card hover stacking

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,9 +99,11 @@
             display: grid;
             gap: 8px;
             align-content: start;
-            transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+            transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease, z-index 0ms;
             will-change: transform;
             box-shadow: 0 8px 20px rgba(12, 22, 44, 0.08);
+            position: relative;
+            z-index: 1;
         }
 
         .metric-card:hover,
@@ -109,6 +111,7 @@
             transform: translateY(-3px) scale(1.02);
             box-shadow: 0 14px 30px rgba(12, 22, 44, 0.14);
             border-color: color-mix(in srgb, var(--brand) 32%, rgba(24,34,53,.12));
+            z-index: 2;
         }
 
         .metric-number {


### PR DESCRIPTION
## Summary
- elevate metric cards on hover with positioning and z-index to prevent overlap clipping

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69294a35d200832db2cd4c8938c76625)

## Summary by Sourcery

Adjust metric card styling to raise hovered cards above neighboring elements and prevent visual clipping.

Enhancements:
- Set metric cards to use relative positioning with explicit z-index to ensure proper stacking order during hover.
- Extend metric card transition properties to include z-index for smoother visual behavior when hovering.