### PR TITLE
Update Cerbi homepage messaging and package listings

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,25 +808,28 @@
             <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Enterprise .NET logging with built-in governance. Deploy in hours, not months. Turn your logs into compliant, ML-ready assets.</p>
 
             <!-- Executive Stats Banner -->
-            <div id="heroMetrics" class="metrics-shell">
-                <div class="metrics-grid">
-                    <article class="metric-card">
-                        <div class="metric-number">40%</div>
-                        <div class="metric-label">Log spend eliminated</div>
-                        <p class="metric-note">In the first 90 days of rollout.</p>
-                    </article>
-                    <article class="metric-card">
-                        <div class="metric-number">95%</div>
-                        <div class="metric-label">Compliance pass rate</div>
-                        <p class="metric-note">On first audit with Cerbi controls.</p>
-                    </article>
-                    <article class="metric-card">
-                        <div class="metric-number">3x</div>
-                        <div class="metric-label">Faster incident response</div>
-                        <p class="metric-note">After instrumenting runbooks end-to-end.</p>
-                    </article>
-                </div>
-            </div>
+                    <div id="heroMetrics" class="metrics-shell">
+                        <div class="metrics-grid">
+                            <article class="metric-card">
+                                <div class="metric-number">40%</div>
+                                <div class="metric-label">Log spend eliminated</div>
+                                <p class="metric-note">Median reduction in paid log volume for early adopters in the first 90 days.</p>
+                            </article>
+                            <article class="metric-card">
+                                <div class="metric-number">95%</div>
+                                <div class="metric-label">First-audit pass rate</div>
+                                <p class="metric-note">Compliance checks passed on first audit when teams enforced Cerbi governance profiles.</p>
+                            </article>
+                            <article class="metric-card">
+                                <div class="metric-number">3x</div>
+                                <div class="metric-label">Faster incident response</div>
+                                <p class="metric-note">Time-to-resolution improvement after instrumenting runbooks with governed, searchable logs.</p>
+                            </article>
+                        </div>
+                        <p class="muted" style="text-align:center;margin:14px auto 0;max-width:780px;font-size:13px">
+                            Results are based on internal benchmarks and pilot rollouts; actual results will vary.
+                        </p>
+                    </div>
 
             <!-- Dual CTAs -->
             <div class="hero-ctas">
@@ -884,7 +887,7 @@
         <section id="brief-overview-video" class="container section">
             <div class="eyebrow">Overview</div>
             <h2>Cerbi — <span class="hl">Brief Overview</span></h2>
-            <p class="lead">Short walkthrough of what Cerbi is, why it exists, and how it fits into your observability stack.</p>
+            <p class="lead">CerbiStream is a governance-first logging layer for .NET that validates, redacts, and tags every log event before it hits your sinks. Instead of shipping “whatever the app logs” into expensive platforms, Cerbi enforces JSON profiles so only clean, compliant, ML-ready data flows downstream. CerbiShield, the governance dashboard, generates and deploys those profiles across teams so policy lives outside code. Together, they turn logging from an ungoverned cost center into an auditable, measurable part of your architecture.</p>
             <div class="card" style="padding:16px;">
                 <div class="video-container">
                     <video controls preload="metadata" playsinline>
@@ -955,28 +958,28 @@
         <!-- Security & Compliance Section -->
         <section id="security" class="container section" style="background:linear-gradient(135deg, rgba(255,77,0,.08) 0%, rgba(20,40,72,.06) 100%);color:var(--text-strong);border-radius:20px;padding:64px 48px;margin:48px auto;border:1px solid rgba(20,40,72,.08);box-shadow:0 22px 60px rgba(20,40,72,.08)">
             <div class="eyebrow" style="color:rgba(20,40,72,.75)">Enterprise-Grade Security</div>
-            <h2 style="color:var(--text-strong)">Built for <span class="hl">Compliance</span> from Day One</h2>
+            <h2 id="compliance" style="color:var(--text-strong)">Built for <span class="hl">Compliance</span> from Day One</h2>
             <p class="lead" style="color:rgba(24,34,53,.9);max-width:800px;margin:0 auto 3rem">
-                CerbiSuite was designed by security-conscious engineers for security-conscious organizations. Every feature prioritizes data protection, audit trails, and regulatory compliance.
+                Cerbi was designed for regulated workloads. Governance profiles let you define required, forbidden, and disallowed fields, plus redaction rules, so PII and PHI don’t leak into your log pipeline by accident. CerbiShield lets you version and deploy these profiles per app and environment, so auditors can see exactly what is enforced and where. We don’t promise “automatic compliance”—instead, we give you the guardrails and evidence you need to pass real audits.
             </p>
 
             <div class="security-grid">
                 <div class="security-card">
                     <div class="security-icon">🔒</div>
                     <h3>Encryption at Rest & In Transit</h3>
-                    <p>AES-256 encryption with configurable key rotation. TLS 1.3 for all data transmission. Your logs stay secure from source to storage.</p>
+                    <p>AES-256 file encryption is available for fallback logs, and Cerbi fits cleanly into TLS-secured infrastructure. Exact cipher suites and TLS versions are controlled by your hosting platform and configuration. Cerbi does not weaken your existing security posture.</p>
                 </div>
                 
                 <div class="security-card">
                     <div class="security-icon">🛡️</div>
                     <h3>Automatic PII Redaction</h3>
-                    <p>ML-powered detection identifies and redacts sensitive data before it's logged. Policy enforcement prevents PII leakage across your entire codebase.</p>
+                    <p>Rule-based redaction identifies and masks sensitive fields before they are written to your sinks. Governance profiles keep PII and PHI out of your log payloads by design. Optional analytics and future ML components can build on the same metadata, but core redaction is explicit and policy-driven.</p>
                 </div>
                 
                 <div class="security-card">
                     <div class="security-icon">✅</div>
                     <h3>Compliance Ready</h3>
-                    <p>Built-in audit trails meet SOC 2 Type II, HIPAA, GDPR, and ISO 27001 requirements. Generate compliance reports in minutes, not weeks.</p>
+                    <p>Built-in audit trails and governance metadata are designed to help you address common SOC 2 Type II, HIPAA, GDPR, and ISO 27001 logging controls. Cerbi itself is not a substitute for legal review or formal certification, but it gives your security and compliance teams the evidence they expect from a modern logging layer.</p>
                 </div>
                 
                 <div class="security-card">
@@ -988,13 +991,13 @@
                 <div class="security-card">
                     <div class="security-icon">🔐</div>
                     <h3>Your Infrastructure, Your Control</h3>
-                    <p>Your logs never leave your environment. No data sent to third-party services. Complete control over retention, access, and deletion.</p>
+                    <p>By default, Cerbi runs entirely in your tenant so logs stay in your environment. Optional analytics services can consume derived metadata if you choose to enable them, but Cerbi does not ship your raw logs to shared SaaS by default.</p>
                 </div>
 
                 <div class="security-card">
                     <div class="security-icon">📝</div>
                     <h3>Immutable Audit Logs</h3>
-                    <p>Tamper-proof audit trails track every access, change, and export. Perfect for forensics, compliance audits, and incident response.</p>
+                    <p>Append-only audit trails make access and changes tamper-evident, providing a forensic trail for investigations and audits.</p>
                 </div>
             </div>
 
@@ -1004,28 +1007,28 @@
                         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
                         <path d="M9 12l2 2 4-4"/>
                     </svg>
-                    SOC 2 Type II Ready
+                    SOC 2 Type II aligned
                 </span>
                 <span class="compliance-badge">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
                         <path d="M9 12l2 2 4-4"/>
                     </svg>
-                    HIPAA Compliant
+                    HIPAA logging friendly
                 </span>
                 <span class="compliance-badge">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
                         <path d="M9 12l2 2 4-4"/>
                     </svg>
-                    GDPR Ready
+                    GDPR aware
                 </span>
                 <span class="compliance-badge">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
                         <path d="M9 12l2 2 4-4"/>
                     </svg>
-                    ISO 27001
+                    ISO 27001 aligned
                 </span>
             </div>
 
@@ -1034,6 +1037,12 @@
                     🔒 Request Security Whitepaper
                 </a>
             </div>
+        </section>
+
+        <section id="ai-ready" class="container section">
+            <div class="eyebrow">AI-ready</div>
+            <h2>AI-ready, not <span class="hl">AI-locked-in</span></h2>
+            <p class="lead">Cerbi doesn’t try to be your AI platform. It focuses on producing clean, structured, governance-tagged logs that any AI stack can consume. Whether you’re using Databricks, OpenSearch, self-hosted RAG, or vendor LLMs, Cerbi adds consistent fields like GovernanceViolations, GovernanceProfileUsed, and GovernanceRelaxed so downstream analysis and scoring stay predictable. You decide which models to run and where; Cerbi simply makes the data safe and usable.</p>
         </section>
 
         <section id="why" class="container section">
@@ -1057,7 +1066,7 @@
 
         <section id="quickstart" class="container section">
             <div class="eyebrow">Get started</div>
-            <h2>⚡ <span class="hl">Quick Start</span>: Try <span class="hl">CerbiStream</span> in 60 Seconds</h2>
+            <h2 id="developers">⚡ <span class="hl">Quick Start</span>: Try <span class="hl">CerbiStream</span> in 60 Seconds</h2>
             <p class="lead">Install from NuGet, configure in <code>Program.cs</code>, and log safely with governance validation.</p>
 
             <div class="card" style="padding:18px;position:relative">
@@ -1274,7 +1283,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
         <!-- Sales & ROI Charts -->
         <section id="sales-roi" class="section">
             <div class="container">
-                <h2 class="section-title">Sales & ROI Impact</h2>
+                <h2 id="leaders" class="section-title">Sales & ROI Impact</h2>
                 <p class="section-subtitle">
                     Our SaaS platform delivers measurable business outcomes.
                     The following charts illustrate how organizations benefit in terms of <strong>cost savings</strong>,
@@ -1385,9 +1394,9 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
         <section id="packages" class="container section">
             <div class="eyebrow">Install</div>
-            <h2><span class="hl">NuGet Packages</span> (live)</h2>
-            <p style="text-align:center;max-width:700px;margin:0 auto 1rem;color:var(--muted);font-size:15px">
-                Click any package card to flip and reveal install commands & live statistics from NuGet.org
+            <h2>Install from NuGet: <span class="hl">Cerbi Packages</span> (live)</h2>
+            <p style="text-align:center;max-width:820px;margin:0 auto 1rem;color:var(--muted);font-size:15px">
+                Install the core Cerbi packages directly from NuGet. Click any package card to flip and reveal install commands & live statistics from NuGet.org.
             </p>
             <div id="nugetGrid"></div>
             <template id="nugetCardTpl">
@@ -1449,7 +1458,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                 </div>
                             </div>
                             <a class="btn btn-primary pkg-link-back" target="_blank" rel="noopener" style="width:100%;margin-top:16px">
-                                View on NuGet.org →
+                                NuGet →
                             </a>
                         </div>
                     </div>
@@ -1503,10 +1512,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <!-- Repository cards arranged in orbit -->
                 <div class="repo-orbit">
                     <!-- CerbiStream -->
-                    <article class="repo-node" data-repo="cerbistream" tabindex="0">
+                    <article class="repo-node" data-repo="cerbistream" data-link="https://github.com/Zeroshi/Cerbi-CerbiStream" tabindex="0">
                         <div class="repo-icon">🚀</div>
                         <h3 class="repo-name">CerbiStream</h3>
-                        <p class="repo-tagline">Core Logger</p>
+                        <p class="repo-tagline">Core logging engine with governance enforcement and file fallback.</p>
                         <div class="repo-status">
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-net">.NET 6-8</span>
@@ -1514,10 +1523,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </article>
 
                     <!-- Governance Analyzer -->
-                    <article class="repo-node" data-repo="analyzer" tabindex="0">
+                    <article class="repo-node" data-repo="analyzer" data-link="https://github.com/Zeroshi/Cerbi-CerbiStream" tabindex="0">
                         <div class="repo-icon">🔍</div>
                         <h3 class="repo-name">GovernanceAnalyzer</h3>
-                        <p class="repo-tagline">Build-Time Checks</p>
+                        <p class="repo-tagline">Roslyn analyzers for compile-time governance checks.</p>
                         <div class="repo-status">
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-roslyn">Roslyn</span>
@@ -1525,10 +1534,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </article>
 
                     <!-- MEL Governance -->
-                    <article class="repo-node" data-repo="mel" tabindex="0">
+                    <article class="repo-node" data-repo="mel" data-link="https://www.nuget.org/packages/Cerbi.MEL.Governance" tabindex="0">
                         <div class="repo-icon">⚡</div>
                         <h3 class="repo-name">MEL.Governance</h3>
-                        <p class="repo-tagline">Runtime Validation</p>
+                        <p class="repo-tagline">Runtime adapter for Microsoft.Extensions.Logging pipelines.</p>
                         <div class="repo-status">
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-mel">MEL</span>
@@ -1536,10 +1545,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </article>
 
                     <!-- CerbiShield -->
-                    <article class="repo-node" data-repo="shield" tabindex="0">
+                    <article class="repo-node" data-repo="shield" data-link="https://github.com/Zeroshi/Cerbi-CerbiStream" tabindex="0">
                         <div class="repo-icon">🛡️</div>
                         <h3 class="repo-name">CerbiShield</h3>
-                        <p class="repo-tagline">Dashboard & APIs</p>
+                        <p class="repo-tagline">Governance dashboard, rule store, and deployment APIs (tenant-hosted).</p>
                         <div class="repo-status">
                             <span class="badge badge-beta">Beta</span>
                             <span class="badge badge-web">Web</span>
@@ -1547,10 +1556,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </article>
 
                     <!-- Serilog Analyzer -->
-                    <article class="repo-node" data-repo="serilog" tabindex="0">
+                    <article class="repo-node" data-repo="serilog" data-link="https://www.nuget.org/packages/Cerbi.Serilog.GovernanceAnalyzer" tabindex="0">
                         <div class="repo-icon">📊</div>
                         <h3 class="repo-name">Serilog.Analyzer</h3>
-                        <p class="repo-tagline">Serilog Support</p>
+                        <p class="repo-tagline">Serilog-specific governance adapter and score shipper.</p>
                         <div class="repo-status">
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-serilog">Serilog</span>
@@ -1558,10 +1567,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </article>
 
                     <!-- Governance Core -->
-                    <article class="repo-node" data-repo="core" tabindex="0">
+                    <article class="repo-node" data-repo="core" data-link="https://www.nuget.org/packages/Cerbi.Governance.Core" tabindex="0">
                         <div class="repo-icon">⚙️</div>
                         <h3 class="repo-name">Governance.Core</h3>
-                        <p class="repo-tagline">Shared Models</p>
+                        <p class="repo-tagline">Shared contracts and enums that keep all components aligned.</p>
                         <div class="repo-status">
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-lib">Library</span>
@@ -2848,7 +2857,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <span class="faq-icon">+</span>
                     </div>
                     <div class="faq-answer">
-                        <p>Most teams migrate in under 2 hours. CerbiStream uses familiar .NET logging abstractions and provides migration scripts. You can run CerbiStream alongside your existing logger during the transition. Our documentation includes step-by-step migration guides for Serilog, NLog, and Microsoft.Extensions.Logging.</p>
+                        <p>CerbiStream uses familiar .NET logging abstractions and can run alongside Serilog, NLog, or MEL during rollout. You can enable Cerbi for a subset of services first, validate governance profiles, and then expand as you gain confidence. Many teams can prototype migration in an afternoon, but full cut-over timing depends on your codebase and the governance rules you choose to enforce.</p>
                     </div>
                 </div>
 
@@ -3310,12 +3319,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             if (!grid || !tpl) return;
 
             const pkgs = [
-                { id: 'CerbiStream', desc: 'Structured logger with async buffer, encryption, and governance hooks.' },
-                { id: 'Cerbi.MEL.Governance', desc: 'Runtime governance for Microsoft.Extensions.Logging; redaction & relax-mode.' },
-                { id: 'CerbiStream.GovernanceAnalyzer', desc: 'Roslyn analyzer diagnostics for schema/PII with CI-friendly IDs.' },
-                { id: 'Cerbi.Governance.Runtime', desc: 'Runtime enforcement engine shared by plugins.' },
-                { id: 'Cerbi.Governance.Core', desc: 'Core models (profiles, results) + plugin contracts.' },
-                { id: 'Cerbi.Serilog.GovernanceAnalyzer', desc: 'Analyzer support for Serilog projects.' }
+                { id: 'CerbiStream', desc: 'Governance-first logger for .NET with redaction, encryption, and async buffering.' },
+                { id: 'Cerbi.Governance.Runtime', desc: 'Runtime engine for enforcing Cerbi governance profiles and tagging logs with violations.' },
+                { id: 'CerbiStream.GovernanceAnalyzer', desc: 'Roslyn analyzer that validates CerbiStream logs against governance profiles at build time.' },
+                { id: 'Cerbi.Serilog.GovernanceAnalyzer', desc: 'Serilog governance adapter that enforces profiles and ships governance scores.' }
             ];
 
             function fmtDownloads(n) {
@@ -4045,8 +4052,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 cerbistream: {
                     icon: '🚀',
                     title: 'CerbiStream',
-                    tagline: 'Core .NET Logger with Structured Output',
-                    description: 'High-performance structured logger with async Channel&lt;T&gt; pipeline, encrypted file rotation, and governance hooks. Production-ready for .NET 6, 7, and 8.',
+                    tagline: 'Core logging engine with governance enforcement and file fallback.',
+                    description: 'High-performance structured logger with governance enforcement, async buffering, and encrypted file fallback so governed data reaches every sink reliably.',
                     features: [
                         'Channel&lt;T&gt; async path for non-blocking writes',
                         'File fallback with encrypted rotation',
@@ -4063,8 +4070,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 analyzer: {
                     icon: '🔍',
                     title: 'CerbiStream.GovernanceAnalyzer',
-                    tagline: 'Build-Time Governance Validation',
-                    description: 'Roslyn analyzer that flags governance violations during build and in your IDE. Catches schema/PII issues before they reach production.',
+                    tagline: 'Roslyn analyzers for compile-time governance checks.',
+                    description: 'Roslyn analyzers that validate CerbiStream events against governance profiles at build time, keeping schemas and redaction rules enforced before deployment.',
                     features: [
                         'Real-time diagnostics in Visual Studio / VS Code',
                         'CI/CD integration for automated checks',
@@ -4073,15 +4080,15 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         'Code fix suggestions for common violations'
                     ],
                     links: [
-                        { text: 'View on NuGet', url: 'https://www.nuget.org/packages/CerbiStream.GovernanceAnalyzer', primary: true },
-                        { text: 'Documentation', url: 'https://github.com/Zeroshi/Cerbi-CerbiStream#governance-analyzer', primary: false }
+                        { text: 'View on GitHub', url: 'https://github.com/Zeroshi/Cerbi-CerbiStream', primary: true },
+                        { text: 'NuGet Package', url: 'https://www.nuget.org/packages/CerbiStream.GovernanceAnalyzer', primary: false }
                     ]
                 },
                 mel: {
                     icon: '⚡',
                     title: 'Cerbi.MEL.Governance',
-                    tagline: 'Runtime Validation for Microsoft.Extensions.Logging',
-                    description: 'Runtime governance plugin that enforces JSON profiles, tags violations, and supports relax-mode for safe production rollout.',
+                    tagline: 'Runtime adapter for Microsoft.Extensions.Logging pipelines.',
+                    description: 'Adapter that enforces Cerbi governance profiles inside MEL pipelines, tagging violations and supporting relax-mode for progressive rollout.',
                     features: [
                         'Enforces required/forbidden fields, types, enums',
                         'Tags violations without dropping logs',
@@ -4097,8 +4104,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 shield: {
                     icon: '🛡️',
                     title: 'CerbiShield',
-                    tagline: 'Governance Dashboard & Management APIs',
-                    description: 'Central dashboard for profile authoring, RBAC, audit history, and environment-aware deployments. Visualize compliance trends and drill into violations.',
+                    tagline: 'Governance dashboard, rule store, and deployment APIs (tenant-hosted).',
+                    description: 'Central governance hub for profile authoring, RBAC, audit history, and environment-aware deployments. Keeps policy outside code while remaining tenant-hosted.',
                     features: [
                         'Profile authoring with Monaco editor',
                         'RBAC with team-based permissions',
@@ -4107,14 +4114,14 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         'Real-time compliance scorecards'
                     ],
                     links: [
-                        { text: 'Coming Soon', url: '#', primary: true }
+                        { text: 'View placeholder', url: 'https://github.com/Zeroshi/Cerbi-CerbiStream', primary: true }
                     ]
                 },
                 serilog: {
                     icon: '📊',
                     title: 'Cerbi.Serilog.GovernanceAnalyzer',
-                    tagline: 'Governance Validation for Serilog',
-                    description: 'Roslyn analyzer that brings governance checks to Serilog projects. Compatible with all existing Serilog sinks and enrichers.',
+                    tagline: 'Serilog-specific governance adapter and score shipper.',
+                    description: 'Serilog-focused governance adapter that enforces profiles and ships governance scores alongside your existing Serilog sinks and enrichers.',
                     features: [
                         'Checks Serilog logs against governance profiles',
                         'Diagnostics for required/forbidden fields',
@@ -4130,8 +4137,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 core: {
                     icon: '⚙️',
                     title: 'Cerbi.Governance.Core',
-                    tagline: 'Shared Models & Plugin Contracts',
-                    description: 'Core library with shared models for profiles, validation results, and plugin contracts. Foundation for all governance components.',
+                    tagline: 'Shared contracts and enums that keep all components aligned.',
+                    description: 'Shared contracts, enums, and profile models that keep every Cerbi component aligned across analyzers and runtime adapters.',
                     features: [
                         'Profile schema definitions',
                         'Validation result models',
@@ -4186,6 +4193,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             // Attach click handlers
             document.querySelectorAll('.repo-node').forEach(node => {
                 node.addEventListener('click', () => {
+                    const link = node.getAttribute('data-link');
+                    if (link) {
+                        window.open(link, '_blank', 'noopener');
+                    }
                     const repoKey = node.getAttribute('data-repo');
                     showRepoDetail(repoKey);
                 });
@@ -4193,6 +4204,10 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 node.addEventListener('keydown', (e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
+                        const link = node.getAttribute('data-link');
+                        if (link) {
+                            window.open(link, '_blank', 'noopener');
+                        }
                         const repoKey = node.getAttribute('data-repo');
                         showRepoDetail(repoKey);
                     }


### PR DESCRIPTION
## Summary
- refresh hero metrics, overview copy, compliance messaging, and add deep-link anchors for key sections
- soften security and migration claims while adding AI-focused positioning and compliance guardrail language
- update NuGet package cards and ecosystem links with concrete packages, descriptions, and outbound targets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929502d7088832da5dec8526bd4041e)

## Summary by Sourcery

Refresh Cerbi homepage messaging to better position governance, compliance guardrails, and AI-readiness while clarifying claims and linking key sections for targeted audiences.

New Features:
- Add an AI-ready section describing how Cerbi produces governance-tagged logs suitable for any AI stack.
- Introduce deep-link anchors for compliance, developer quickstart, and leadership ROI sections to support role-based navigation.
- Enable ecosystem repo cards to open their associated GitHub or NuGet pages on click or keyboard activation.

Enhancements:
- Clarify hero metrics copy and add a disclaimer to make outcome claims more precise and transparent.
- Rewrite overview, security, and compliance messaging to emphasize governance profiles, auditability, and realistic compliance positioning.
- Refine migration FAQ language to set more measured expectations around migration effort and rollout patterns.
- Update NuGet/package and ecosystem card titles, taglines, and descriptions to better explain each package’s role in the Cerbi stack.
- Adjust NuGet package list and labels, including button text, to focus on core governance components and their concrete capabilities.

Documentation:
- Improve homepage explanatory copy to clearly differentiate CerbiStream, CerbiShield, and related components and how they fit into .NET logging architectures.