### PR TITLE
Add ROI disclaimer note to draft page

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -1371,6 +1371,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <li><strong>Stable schemas:</strong> fewer broken charts/alerts → less rework and query churn.</li>
                             <li><strong>Policy + redaction:</strong> audit evidence inline → reduced compliance overhead.</li>
                         </ul>
+                        <p class="muted" style="font-size:13px;margin-top:10px">Note: These are illustrative examples based on internal benchmarks and early pilot assumptions. Actual results will vary by stack, volume, and the governance policies you choose to enforce.</p>
                     </article>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add muted ROI disclaimer note beneath the ROI levers list on the draft page

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929da25f81c832d912b5688446a3ce8)

## Summary by Sourcery

New Features:
- Display a muted disclaimer beneath the ROI levers list explaining that the ROI examples are illustrative and actual results will vary.