### PR TITLE
Add muted styling for ROI lever note

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -1371,7 +1371,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <li><strong>Stable schemas:</strong> fewer broken charts/alerts → less rework and query churn.</li>
                             <li><strong>Policy + redaction:</strong> audit evidence inline → reduced compliance overhead.</li>
                         </ul>
-                        <p class="muted" style="font-size:13px;margin-top:10px">Note: These are illustrative examples based on internal benchmarks and early pilot assumptions. Actual results will vary by stack, volume, and the governance policies you choose to enforce.</p>
+                        <small class="muted" style="display:block;font-size:13px;margin-top:10px">Note: These are illustrative examples based on internal benchmarks and early pilot assumptions. Actual results will vary by stack, volume, and the governance policies you choose to enforce.</small>
                     </article>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -1344,7 +1344,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <li><strong>Stable schemas:</strong> fewer broken charts/alerts → less rework and query churn.</li>
                             <li><strong>Policy + redaction:</strong> audit evidence inline → reduced compliance overhead.</li>
                         </ul>
-                        <p class="muted" style="font-size:13px;margin-top:10px">Note: These are illustrative examples based on internal benchmarks and early pilot assumptions. Actual results will vary by stack, volume, and the governance policies you choose to enforce.</p>
+                        <small class="muted" style="display:block;font-size:13px;margin-top:10px">Note: These are illustrative examples based on internal benchmarks and early pilot assumptions. Actual results will vary by stack, volume, and the governance policies you choose to enforce.</small>
                     </article>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- style the ROI levers note as small muted text directly under the list on the Sales & ROI Impact section in both index pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dbc1e4f0832d8e798f8a68883ada)

## Summary by Sourcery

Enhancements:
- Adjust ROI leverage note markup to use small muted text for clearer, de-emphasized presentation on both index pages.