### PR TITLE
Update CerbiSuite licensing FAQ answer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2610,15 +2610,22 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </div>
                 </div>
 
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Is CerbiSuite open source? What's the licensing model?</h3>
-                        <span class="faq-icon">+</span>
+                    <div class="faq-item">
+                        <div class="faq-question">
+                            <h3>Is CerbiSuite open source? What's the licensing model?</h3>
+                            <span class="faq-icon">+</span>
+                        </div>
+                        <div class="faq-answer">
+                            <p>
+                                CerbiStream core and the shared governance libraries (for example, Cerbi.Governance.Core and
+                                Cerbi.Governance.Runtime) are open source under the MIT license. You can use them in both open
+                                source and commercial projects. CerbiShield (the governance dashboard, APIs, and reporting) is
+                                licensed commercially for enterprise customers, with subscriptions that include support, SLAs,
+                                and advanced features. Check each repo or NuGet page for the exact license, but the general
+                                rule is: logging/runtime pieces are permissive, governance/dashboard/reporting are paid.
+                            </p>
+                        </div>
                     </div>
-                    <div class="faq-answer">
-                        <p>CerbiStream core and the shared governance libraries (for example, Cerbi.Governance.Core and Cerbi.Governance.Runtime) are open source under the MIT license. You can use them in both open source and commercial projects. CerbiShield (the governance dashboard, APIs, and reporting) is licensed commercially for enterprise customers, with subscriptions that include support, SLAs, and advanced features. Check each repo or NuGet page for the exact license, but the general rule is: logging/runtime pieces are permissive, governance/dashboard/reporting are paid.</p>
-                    </div>
-                </div>
 
                 <div class="faq-item">
                     <div class="faq-question">


### PR DESCRIPTION
## Summary
- reformat and restate the CerbiSuite licensing FAQ answer with current licensing details

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929e9d8b91c832db7441946aae46a8b)

## Summary by Sourcery

Enhancements:
- Adjust the CerbiSuite licensing FAQ markup to match surrounding FAQ-item structure and formatting.