### PR TITLE
Update X social links to new handle

### DIFF
--- a/index.html
+++ b/index.html
@@ -2759,7 +2759,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             </svg>
                             YouTube
                         </a>
-                        <a class="chip" href="https://x.com/CerbiSuite" target="_blank" rel="noopener" style="width:fit-content">
+                        <a class="chip" href="https://x.com/hellocerbi" target="_blank" rel="noopener" style="width:fit-content">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:-2px;margin-right:4px">
                                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
                             </svg>
@@ -2794,7 +2794,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
                         </svg>
                     </a>
-                    <a href="https://x.com/CerbiSuite" target="_blank" rel="noopener" aria-label="X" style="color:var(--muted);transition:color .2s">
+                    <a href="https://x.com/hellocerbi" target="_blank" rel="noopener" aria-label="X" style="color:var(--muted);transition:color .2s">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
                         </svg>


### PR DESCRIPTION
## Summary
- update Connect section X link to point to the new @hellocerbi profile
- update footer X icon link to the same handle

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929ef675a5c832dae6ec32558c7c63b)

## Summary by Sourcery

Bug Fixes:
- Correct X profile URLs so they direct to the current @hellocerbi handle instead of the outdated @CerbiSuite account.