### PR TITLE
Update Cerbi ecosystem copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1480,7 +1480,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
         <section id="repos" class="container section">
             <div class="eyebrow">Open Source</div>
             <h2><span class="hl">Explore</span> the Cerbi Ecosystem</h2>
-            <p class="lead">Dive into our open-source repositories. Click any component to explore its role in the architecture.</p>
+            <p class="lead">From structured logs to governance scores and dashboards, each piece plays a specific role in the pipeline.</p>
 
             <div class="repo-ecosystem">
                 <!-- Central hub -->
@@ -1489,7 +1489,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <img src="assets/CerbiLogoEmblem.png" alt="Cerbi" style="width:72px;height:72px;border-radius:16px;filter:drop-shadow(0 0 16px rgba(255,77,0,.4))">
                     </div>
                     <div class="hub-title">CerbiSuite</div>
-                    <div class="hub-subtitle">Unified Logging Ecosystem</div>
+                    <div class="hub-subtitle">Unified logging, governance, and scoring for .NET teams.</div>
                 </div>
 
                 <!-- Repository cards arranged in orbit -->


### PR DESCRIPTION
## Summary
- refresh the Explore the Cerbi Ecosystem intro line
- update the CerbiSuite hub subtitle with logging and governance focus

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929f2970804832d80b60d499cdf103a)

## Summary by Sourcery

Refresh Cerbi ecosystem marketing copy on the main index page.

Enhancements:
- Update the Cerbi ecosystem lead text to emphasize structured logs, governance, and dashboards within the pipeline.
- Refine the CerbiSuite hub subtitle to highlight unified logging, governance, and scoring for .NET teams.