### PR TITLE
Add role helper text to ecosystem cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1503,6 +1503,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-net">.NET 6-8</span>
                         </div>
+                        <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Source logger + governance metadata.</p>
                     </article>
 
                     <!-- Governance Analyzer -->
@@ -1514,6 +1515,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-roslyn">Roslyn</span>
                         </div>
+                        <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Build-time guardrails.</p>
                     </article>
 
                     <!-- MEL Governance -->
@@ -1525,6 +1527,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-mel">MEL</span>
                         </div>
+                        <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Runtime validator + score shipper.</p>
                     </article>
 
                     <!-- CerbiShield -->
@@ -1536,6 +1539,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <span class="badge badge-beta">Beta</span>
                             <span class="badge badge-web">Web</span>
                         </div>
+                        <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Governance brain and dashboards.</p>
                     </article>
 
                     <!-- Serilog Analyzer -->
@@ -1547,6 +1551,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-serilog">Serilog</span>
                         </div>
+                        <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Serilog runtime governance and scoring.</p>
                     </article>
 
                     <!-- Governance Core -->
@@ -1558,6 +1563,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <span class="badge badge-ga">GA</span>
                             <span class="badge badge-lib">Library</span>
                         </div>
+                        <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Shared contracts and scoring types.</p>
                     </article>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add muted role descriptions beneath the status badges for each ecosystem component card on the homepage
- clarify pipeline responsibilities for CerbiStream, GovernanceAnalyzer, MEL Governance, CerbiShield, the Serilog analyzer, and Governance Core

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929f2b1ca90832da708aa716da91ad7)

## Summary by Sourcery

New Features:
- Display muted role helper text under the status badges for CerbiStream, GovernanceAnalyzer, MEL.Governance, CerbiShield, Serilog.Analyzer, and Governance.Core cards on the homepage.