### PR TITLE
Add Serilog governance analyzer NuGet card

### DIFF
--- a/index.html
+++ b/index.html
@@ -1452,6 +1452,16 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <span class="mono">dotnet add package Cerbi.Governance.Runtime</span>
                     </div>
                 </article>
+                <article class="card nuget-card">
+                    <div class="pkg-head">
+                        <h3 class="pkg-title">Cerbi.Serilog.GovernanceAnalyzer</h3>
+                        <a class="btn btn-ghost pkg-link" href="https://www.nuget.org/packages/Cerbi.Serilog.GovernanceAnalyzer" target="_blank" rel="noopener">NuGet →</a>
+                    </div>
+                    <p class="muted pkg-desc">Serilog governance plugin that enforces Cerbi profiles at runtime and ships scoring metadata into CerbiShield.</p>
+                    <div class="pkg-command">
+                        <span class="mono">dotnet add package Cerbi.Serilog.GovernanceAnalyzer</span>
+                    </div>
+                </article>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add Cerbi.Serilog.GovernanceAnalyzer NuGet card to the install section on the homepage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929f2beec48832d9ca81aef5df0d51f)

## Summary by Sourcery

New Features:
- Expose the Cerbi.Serilog.GovernanceAnalyzer package on the homepage with a NuGet card including link and install command.