### PR TITLE
Update Cerbi ecosystem cards with canonical links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1507,7 +1507,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     <div class="pipeline-stack">
                         <div class="stack-header">Ecosystem overview</div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="suite" data-link="https://github.com/Zeroshi/Cerbi-CerbiStream" tabindex="0">
+                            <article class="repo-node" data-repo="suite" data-link="https://github.com/Zeroshi" tabindex="0">
                                 <div class="repo-icon">🧭</div>
                                 <h3 class="repo-name">CerbiSuite</h3>
                                 <p class="repo-tagline">Unified logging, governance, and scoring for .NET teams.</p>
@@ -1555,7 +1555,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     <div class="pipeline-stack">
                         <div class="stack-header">Stage 3 – Runtime governance &amp; scoring</div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="mel" data-link="https://www.nuget.org/packages/Cerbi.MEL.Governance" tabindex="0">
+                            <article class="repo-node" data-repo="mel" data-link="https://github.com/Zeroshi/Cerbi.MEL.Governance" tabindex="0">
                                 <div class="repo-icon">⚡</div>
                                 <h3 class="repo-name">Cerbi.MEL.Governance</h3>
                                 <p class="repo-tagline">Runtime governance and scoring adapter for Microsoft.Extensions.Logging; redacts PII and ships score metadata asynchronously.</p>
@@ -1609,7 +1609,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     <div class="pipeline-stack">
                         <div class="stack-header">Stage 5 – Dashboards &amp; reporting</div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="shield" data-link="https://github.com/Zeroshi/Cerbi-CerbiStream" tabindex="0">
+                            <article class="repo-node" data-repo="shield" data-link="https://github.com/Zeroshi" tabindex="0">
                                 <div class="repo-icon">🛡️</div>
                                 <h3 class="repo-name">CerbiShield</h3>
                                 <p class="repo-tagline">Tenant-hosted governance dashboard, profile store, deployments, and governance scorecards for apps, teams, and environments.</p>
@@ -3796,8 +3796,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         'Environment-specific overrides'
                     ],
                     links: [
-                        { text: 'View on NuGet', url: 'https://www.nuget.org/packages/Cerbi.MEL.Governance', primary: true },
-                        { text: 'Demo App', url: 'https://github.com/Zeroshi/Cerbi.MEL.Governance.Demo', primary: false }
+                        { text: 'View on GitHub', url: 'https://github.com/Zeroshi/Cerbi.MEL.Governance', primary: true },
+                        { text: 'NuGet Package', url: 'https://www.nuget.org/packages/Cerbi.MEL.Governance', primary: false }
                     ]
                 },
                 shield: {
@@ -3813,7 +3813,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         'Real-time compliance scorecards'
                     ],
                     links: [
-                        { text: 'View placeholder', url: 'https://github.com/Zeroshi/Cerbi-CerbiStream', primary: true }
+                        { text: 'Cerbi GitHub Org', url: 'https://github.com/Zeroshi', primary: true }
                     ]
                 },
                 serilog: {
@@ -3829,8 +3829,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         'Works with all Serilog sinks'
                     ],
                     links: [
-                        { text: 'View on NuGet', url: 'https://www.nuget.org/packages/Cerbi.Serilog.GovernanceAnalyzer', primary: true },
-                        { text: 'Test App', url: 'https://github.com/Zeroshi/Cerbi.Serilog.GovernanceAnalyzer.TestApp', primary: false }
+                        { text: 'View on NuGet', url: 'https://www.nuget.org/packages/Cerbi.Serilog.GovernanceAnalyzer', primary: true }
                     ]
                 },
                 core: {


### PR DESCRIPTION
## Summary
- point the Explore the Cerbi Ecosystem cards to the correct GitHub or NuGet destinations
- update the detail panel links for MEL governance and CerbiShield to their canonical URLs
- remove a broken Serilog analyzer test app link while keeping the NuGet reference

## Testing
- not run (html change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929fc20a450832da68df35d10339950)

## Summary by Sourcery

Update Cerbi ecosystem HTML links to point to canonical GitHub and NuGet destinations and remove a broken Serilog analyzer test app link.

Bug Fixes:
- Correct CerbiSuite and CerbiShield ecosystem card links to the Cerbi GitHub organization.
- Point MEL governance links to the canonical GitHub repository while retaining a NuGet reference.
- Remove the broken Serilog GovernanceAnalyzer test app link from the detail panel while keeping the NuGet link.

Enhancements:
- Adjust MEL governance detail panel to prioritize the GitHub repository link and clarify the NuGet package link label.
- Update CerbiShield detail panel link text to clearly reference the Cerbi GitHub organization.