### PR TITLE
Stop ecosystem cards from navigating directly to GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -1540,7 +1540,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <h3 class="stack-title">Ecosystem overview</h3>
                         </div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="suite" data-link="https://github.com/Zeroshi" tabindex="0">
+                            <button type="button" class="repo-node" data-repo="suite">
                                 <div class="repo-icon">🧭</div>
                                 <h4 class="repo-name">CerbiSuite</h4>
                                 <p class="repo-tagline">Unified logging, governance, and scoring for .NET teams.</p>
@@ -1549,7 +1549,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                     <span class="badge badge-net">.NET</span>
                                 </div>
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: End-to-end ecosystem that connects source logs, governance profiles, scoring, and dashboards.</p>
-                            </article>
+                            </button>
                         </div>
                     </div>
 
@@ -1559,7 +1559,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <h3 class="stack-title">Source logging</h3>
                         </div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="cerbistream" data-link="https://github.com/Zeroshi/Cerbi-CerbiStream" tabindex="0">
+                            <button type="button" class="repo-node" data-repo="cerbistream">
                                 <div class="repo-icon">🚀</div>
                                 <h4 class="repo-name">CerbiStream</h4>
                                 <p class="repo-tagline">Core .NET logger that attaches governance and scoring metadata at the source, with optional file fallback and encryption.</p>
@@ -1568,7 +1568,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                     <span class="badge badge-net">.NET 6–9+</span>
                                 </div>
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Source logger + governance metadata.</p>
-                            </article>
+                            </button>
                         </div>
                     </div>
 
@@ -1578,7 +1578,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <h3 class="stack-title">Build-time guardrails</h3>
                         </div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="analyzer" data-link="https://github.com/Zeroshi/Cerbi-CerbiStream" tabindex="0">
+                            <button type="button" class="repo-node" data-repo="analyzer">
                                 <div class="repo-icon">🔍</div>
                                 <h4 class="repo-name">CerbiStream.GovernanceAnalyzer</h4>
                                 <p class="repo-tagline">Roslyn analyzers that keep logs aligned with Cerbi governance and scoring rules before they ever hit main.</p>
@@ -1587,7 +1587,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                     <span class="badge badge-roslyn">Roslyn</span>
                                 </div>
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Build-time guardrails.</p>
-                            </article>
+                            </button>
                         </div>
                     </div>
 
@@ -1597,7 +1597,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <h3 class="stack-title">Runtime governance &amp; scoring</h3>
                         </div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="mel" data-link="https://github.com/Zeroshi/Cerbi.MEL.Governance" tabindex="0">
+                            <button type="button" class="repo-node" data-repo="mel">
                                 <div class="repo-icon">⚡</div>
                                 <h4 class="repo-name">Cerbi.MEL.Governance</h4>
                                 <p class="repo-tagline">Runtime governance and scoring adapter for Microsoft.Extensions.Logging; redacts PII and ships score metadata asynchronously.</p>
@@ -1606,9 +1606,9 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                     <span class="badge badge-mel">MEL</span>
                                 </div>
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Runtime validator + score shipper.</p>
-                            </article>
+                            </button>
 
-                            <article class="repo-node" data-repo="serilog" data-link="https://www.nuget.org/packages/Cerbi.Serilog.GovernanceAnalyzer" tabindex="0">
+                            <button type="button" class="repo-node" data-repo="serilog">
                                 <div class="repo-icon">📊</div>
                                 <h4 class="repo-name">Cerbi.Serilog.GovernanceAnalyzer</h4>
                                 <p class="repo-tagline">Serilog governance plugin that enforces profiles at runtime and ships scoring metadata into CerbiShield.</p>
@@ -1617,9 +1617,9 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                     <span class="badge badge-serilog">Serilog</span>
                                 </div>
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Serilog runtime governance and scoring.</p>
-                            </article>
+                            </button>
 
-                            <article class="repo-node" data-repo="runtime" data-link="https://www.nuget.org/packages/Cerbi.Governance.Runtime" tabindex="0">
+                            <button type="button" class="repo-node" data-repo="runtime">
                                 <div class="repo-icon">🧮</div>
                                 <h4 class="repo-name">Cerbi.Governance.Runtime</h4>
                                 <p class="repo-tagline">Shared governance engine that evaluates profiles, tags violations, and computes impact scores for any Cerbi-aware logger.</p>
@@ -1628,7 +1628,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                     <span class="badge badge-lib">Library</span>
                                 </div>
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Runtime validation and scoring engine.</p>
-                            </article>
+                            </button>
                         </div>
                     </div>
 
@@ -1638,7 +1638,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <h3 class="stack-title">Shared contracts</h3>
                         </div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="core" data-link="https://www.nuget.org/packages/Cerbi.Governance.Core" tabindex="0">
+                            <button type="button" class="repo-node" data-repo="core">
                                 <div class="repo-icon">⚙️</div>
                                 <h4 class="repo-name">Cerbi.Governance.Core</h4>
                                 <p class="repo-tagline">Shared contracts, scoring enums, and profile types that keep analyzers, runtime validators, and dashboards in sync.</p>
@@ -1647,7 +1647,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                     <span class="badge badge-lib">Library</span>
                                 </div>
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Shared contracts and scoring types.</p>
-                            </article>
+                            </button>
                         </div>
                     </div>
 
@@ -1657,7 +1657,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <h3 class="stack-title">Dashboards &amp; reporting</h3>
                         </div>
                         <div class="stack-grid">
-                            <article class="repo-node" data-repo="shield" data-link="https://github.com/Zeroshi" tabindex="0">
+                            <button type="button" class="repo-node" data-repo="shield">
                                 <div class="repo-icon">🛡️</div>
                                 <h4 class="repo-name">CerbiShield</h4>
                                 <p class="repo-tagline">Tenant-hosted governance dashboard, profile store, deployments, and governance scorecards for apps, teams, and environments.</p>
@@ -1666,7 +1666,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                     <span class="badge badge-web">Web</span>
                                 </div>
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Governance brain and scorecards.</p>
-                            </article>
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -2380,11 +2380,15 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             .repo-node {
                 position: relative;
                 width: 100%;
+                display: block;
                 background: white;
                 border: 2px solid rgba(20,40,72,.15);
                 border-radius: 16px;
                 padding: 16px;
                 text-align: center;
+                font: inherit;
+                color: inherit;
+                appearance: none;
                 cursor: pointer;
                 transition: all .3s cubic-bezier(0.4, 0, 0.2, 1);
                 box-shadow: 0 4px 16px rgba(10,16,30,.08);
@@ -4065,21 +4069,13 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             // Attach click handlers
             document.querySelectorAll('.repo-node').forEach(node => {
                 node.addEventListener('click', () => {
-                    const link = node.getAttribute('data-link');
-                    if (link) {
-                        window.open(link, '_blank', 'noopener');
-                    }
                     const repoKey = node.getAttribute('data-repo');
                     showRepoDetail(repoKey);
                 });
-                
+
                 node.addEventListener('keydown', (e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
-                        const link = node.getAttribute('data-link');
-                        if (link) {
-                            window.open(link, '_blank', 'noopener');
-                        }
                         const repoKey = node.getAttribute('data-repo');
                         showRepoDetail(repoKey);
                     }


### PR DESCRIPTION
## Summary
- convert ecosystem repo cards into buttons that only trigger the detail modal
- remove automatic GitHub navigation from ecosystem card interactions
- preserve styling and typography by resetting button appearance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0029c4c0832d81a52b753179b537)

## Summary by Sourcery

Convert ecosystem repository cards into non-navigating buttons that only open the detail modal.

Enhancements:
- Replace ecosystem repo card articles with buttons while preserving existing visual styling and typography.
- Remove automatic external navigation behavior from ecosystem card click and keyboard interactions so they solely trigger repo detail display.