### PR TITLE
Isolate ecosystem modal state

### DIFF
--- a/index.html
+++ b/index.html
@@ -4014,6 +4014,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
             const detailPanel = document.getElementById('repoDetail');
             const closeBtn = detailPanel?.querySelector('.repo-detail-close');
+            let selectedComponent = null;
 
             const pipelineStages = Array.from(document.querySelectorAll('.pipeline-stage'));
 
@@ -4040,6 +4041,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             function showRepoDetail(repoKey) {
                 const data = repoData[repoKey];
                 if (!data || !detailPanel) return;
+
+                selectedComponent = repoKey;
 
                 // Populate content
                 detailPanel.querySelector('.repo-detail-icon').textContent = data.icon;
@@ -4072,22 +4075,28 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
                 detailPanel.querySelector('.repo-detail-links').innerHTML = linksHtml;
 
-                // Show panel
+                // Show panel (ecosystem-only)
                 detailPanel.hidden = false;
-                document.body.style.overflow = 'hidden';
             }
 
             function hideRepoDetail() {
-                if (detailPanel) {
-                    detailPanel.hidden = true;
-                    document.body.style.overflow = '';
-                }
+                if (!detailPanel || !selectedComponent) return;
+
+                selectedComponent = null;
+                detailPanel.hidden = true;
             }
 
             // Attach click handlers
             document.querySelectorAll('.repo-node').forEach(node => {
                 node.addEventListener('click', () => {
                     const repoKey = node.getAttribute('data-repo');
+                    if (!repoKey) return;
+
+                    if (selectedComponent === repoKey && !detailPanel.hidden) {
+                        hideRepoDetail();
+                        return;
+                    }
+
                     showRepoDetail(repoKey);
                 });
 
@@ -4095,6 +4104,13 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
                         const repoKey = node.getAttribute('data-repo');
+                        if (!repoKey) return;
+
+                        if (selectedComponent === repoKey && !detailPanel.hidden) {
+                            hideRepoDetail();
+                            return;
+                        }
+
                         showRepoDetail(repoKey);
                     }
                 });


### PR DESCRIPTION
## Summary
- add dedicated selection state for the ecosystem detail modal
- ensure close actions only reset the ecosystem modal without touching other overlays
- allow ecosystem cards to toggle their own modal independently of other popups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0461d2fc832da371159a93771b80)

## Summary by Sourcery

Isolate the ecosystem repository detail modal state so it can be toggled independently without affecting other overlays or the page scroll state.

New Features:
- Track the currently selected ecosystem component for the repository detail modal to support per-card toggling.

Bug Fixes:
- Prevent closing the repository detail modal from inadvertently modifying global page scroll or other overlay states.

Enhancements:
- Allow clicking or keyboard-activating an ecosystem card to toggle its own detail modal open and closed.