### PR TITLE
Add scrollspy highlighting for ecosystem stages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3099,6 +3099,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
     <!-- Swiper JS -->
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
     <script src="scripts/hero-metrics.js"></script>
+    <script src="scripts/ecosystem-scrollspy.js"></script>
 
     <script>
         // Year in footer
@@ -4055,12 +4056,25 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
             function setActiveStage(stageKey) {
                 pipelineStages.forEach(stage => {
-                    stage.classList.toggle('is-active', !!stageKey && stage.dataset.stage === stageKey);
+                    const isActive = !!stageKey && stage.dataset.stage === stageKey;
+                    stage.classList.toggle('is-active', isActive);
+                    if (isActive) {
+                        stage.setAttribute('aria-current', 'step');
+                        stage.setAttribute('aria-pressed', 'true');
+                    } else {
+                        stage.removeAttribute('aria-current');
+                        stage.setAttribute('aria-pressed', 'false');
+                    }
                 });
             }
 
             function clearActiveStage() {
-                setActiveStage(null);
+                const fallbackStage = document.body?.dataset?.ecosystemActiveStage;
+                if (fallbackStage) {
+                    setActiveStage(fallbackStage);
+                } else {
+                    setActiveStage(null);
+                }
             }
 
             document.querySelectorAll('.pipeline-stack[data-stage] .repo-node').forEach(card => {

--- a/scripts/ecosystem-scrollspy.js
+++ b/scripts/ecosystem-scrollspy.js
@@ -1,0 +1,62 @@
+(function () {
+    if (!window.React || !window.ReactDOM) return;
+    const { useEffect, useState } = React;
+    const h = React.createElement;
+
+    function EcosystemScrollSpy() {
+        const [activeStage, setActiveStage] = useState(1);
+
+        useEffect(() => {
+            const sections = [1, 2, 3, 4, 5]
+                .map((n) => document.getElementById(`ecosystem-stage-${n}`))
+                .filter(Boolean);
+
+            if (!('IntersectionObserver' in window)) {
+                return undefined;
+            }
+
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        const id = entry.target.id;
+                        const num = parseInt(id.replace('ecosystem-stage-', ''), 10);
+                        if (!Number.isNaN(num)) {
+                            setActiveStage(num);
+                        }
+                    }
+                });
+            }, { threshold: 0.3 });
+
+            sections.forEach((section) => observer.observe(section));
+
+            return () => observer.disconnect();
+        }, []);
+
+        useEffect(() => {
+            const buttons = Array.from(document.querySelectorAll('.pipeline-stage'));
+            document.body.dataset.ecosystemActiveStage = activeStage ? String(activeStage) : '';
+
+            buttons.forEach((btn) => {
+                const stageNumber = parseInt(btn.dataset.stage || '', 10);
+                const isActive = stageNumber === activeStage;
+
+                btn.classList.toggle('is-active', isActive);
+                if (isActive) {
+                    btn.setAttribute('aria-current', 'step');
+                    btn.setAttribute('aria-pressed', 'true');
+                } else {
+                    btn.removeAttribute('aria-current');
+                    btn.setAttribute('aria-pressed', 'false');
+                }
+            });
+        }, [activeStage]);
+
+        return null;
+    }
+
+    const mount = document.createElement('div');
+    mount.id = 'ecosystem-scrollspy-root';
+    mount.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(mount);
+    ReactDOM.createRoot(mount).render(h(EcosystemScrollSpy));
+})();


### PR DESCRIPTION
## Summary
- add a React-based scrollspy to track and highlight pipeline stages while scrolling the ecosystem section
- sync stage button aria states and fallback behavior with scroll-driven active stage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a074ac3dc832d80cf423cd9f7bc34)

## Summary by Sourcery

Add a scroll-driven ecosystem pipeline stage highlighter and synchronize stage button active and ARIA states with scroll position.

New Features:
- Introduce a React-based scrollspy that tracks ecosystem stage sections via IntersectionObserver and updates the active stage as the user scrolls.

Enhancements:
- Synchronize pipeline stage button visual and ARIA states with the active stage detected by the scrollspy, with a dataset-based fallback when clearing active states.

Build:
- Load the new ecosystem scrollspy script from the main HTML entry point.