### PR TITLE
Remove pipeline stage auto-scroll behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -4047,13 +4047,6 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
             const pipelineStages = Array.from(document.querySelectorAll('.pipeline-stage'));
 
-            const scrollToStage = (id) => {
-                const el = document.getElementById(id);
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }
-            };
-
             function setActiveStage(stageKey) {
                 pipelineStages.forEach(stage => {
                     const isActive = !!stageKey && stage.dataset.stage === stageKey;
@@ -4085,14 +4078,6 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 card.addEventListener('focus', () => setActiveStage(stageKey));
                 card.addEventListener('mouseleave', clearActiveStage);
                 card.addEventListener('blur', clearActiveStage);
-            });
-
-            pipelineStages.forEach(stage => {
-                const stageKey = stage.dataset.stage;
-                stage.addEventListener('click', () => {
-                    if (!stageKey) return;
-                    scrollToStage(`ecosystem-stage-${stageKey}`);
-                });
             });
 
             function showRepoDetail(repoKey) {


### PR DESCRIPTION
## Summary
- stop pipeline stage buttons from triggering scroll-to-section behavior
- keep ecosystem stage sections identified for scroll spy updates

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0962d5a8832d869fb3da43fa7065)

## Summary by Sourcery

Enhancements:
- Remove click-driven scroll-to-section behavior from pipeline stage elements to prevent automatic viewport jumps.