### PR TITLE
Refine CerbiSuite section messaging

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -1874,11 +1874,12 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             </div>
         </section>
 
-        <!-- CerbiSuite philosophy video BEFORE Contact/Get in Touch -->
+        <!-- CerbiSuite story video BEFORE Contact/Get in Touch -->
         <section id="cerbisuite-philosophy-video" class="container section">
             <div class="eyebrow">Vision</div>
-            <h2>CerbiSuite — A New Philosophy</h2>
-            <p class="lead">High-level story for leaders and architects on how CerbiSuite approaches logging, governance, and observability.</p>
+            <h2>Why I Built CerbiSuite</h2>
+            <p class="lead">A candid walkthrough for leaders and architects on where Cerbi fits: what problem it solves, what it doesn’t do, and how it plugs into the stack you already have.</p>
+            <p class="note"><strong>If the video is not implemented yet, show this text:</strong> <em>Video walkthrough coming soon. For now, scroll up for the architecture diagram and ecosystem overview.</em></p>
             <div class="card" style="padding:16px;display:flex;justify-content:center;">
                 <video controls preload="metadata" playsinline
                        style="width:100%;max-width:960px;border-radius:14px;box-shadow:var(--shadow);background:#000">

--- a/index.html
+++ b/index.html
@@ -2767,7 +2767,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </div>
                 </article>
 
-                <!-- Video Card 3: Philosophy -->
+                <!-- Video Card 3: CerbiSuite Story -->
                 <article class="video-card" data-category="deep-dive" data-duration="8:15" data-video-src="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/videos/CerbiSuite__A_New_Philosophy.mp4">
                     <div class="video-thumbnail">
                         <video class="thumbnail-video" preload="metadata" muted playsinline>
@@ -2782,8 +2782,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <span class="video-badge badge-deepdive">Deep Dive</span>
                     </div>
                     <div class="video-info">
-                        <h3 class="video-title">CerbiSuite — A New Philosophy</h3>
-                        <p class="video-description">Explore the philosophy behind CerbiSuite's approach to enterprise governance and compliance.</p>
+                        <h3 class="video-title">Why I Built CerbiSuite</h3>
+                        <p class="video-description">A founder's breakdown of the gaps Cerbi fills, what it deliberately doesn't do, and how it fits alongside existing stack choices.</p>
                         <div class="video-meta">
                             <span class="video-date">📅 Featured</span>
                             <span class="video-views">💡 Strategy</span>
@@ -2854,11 +2854,12 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             </div>
         </section>
 
-        <!-- CerbiSuite Philosophy Video -->
+        <!-- CerbiSuite Story Video -->
         <section id="cerbisuite-philosophy-video" class="container section">
             <div class="eyebrow">Vision</div>
-            <h2>CerbiSuite — <span class="hl">A New Philosophy</span></h2>
-            <p class="lead">High-level story for leaders and architects on how CerbiSuite approaches logging, governance, and observability.</p>
+            <h2>Why I Built CerbiSuite</h2>
+            <p class="lead">A candid walkthrough for leaders and architects on where Cerbi fits: what problem it solves, what it doesn’t do, and how it plugs into the stack you already have.</p>
+            <p class="note"><strong>If the video is not implemented yet, show this text:</strong> <em>Video walkthrough coming soon. For now, scroll up for the architecture diagram and ecosystem overview.</em></p>
             <div class="card" style="padding:16px;">
                 <div class="video-container">
                     <video controls preload="metadata" playsinline>


### PR DESCRIPTION
## Summary
- retitle the CerbiSuite feature section to emphasize the founder’s perspective
- replace marketing-heavy copy with a candid description of Cerbi’s fit and limits
- add fallback note for cases where the walkthrough video is not available

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db8fbff5c832db02af2fa7e3da9d6)

## Summary by Sourcery

Retitle and reframe the CerbiSuite video section to emphasize the founder’s story and clarify the product’s scope, with a fallback message when the walkthrough video is unavailable.

New Features:
- Add a fallback note guiding users when the CerbiSuite walkthrough video is not yet implemented.

Enhancements:
- Update CerbiSuite video titles and descriptions to present a more candid, founder-focused explanation of the product’s role and limitations in the existing stack.