### PR TITLE
Restore hero background imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,7 +523,21 @@
         .more-menu a:hover { background: var(--panel-2) }
         .more[data-open="true"] .more-menu { display: block }
 
-        .hero { padding: 20px 0 8px }
+        .hero {
+            position: relative;
+            padding: 20px 0 8px;
+            isolation: isolate;
+        }
+        .hero::before {
+            content: "";
+            position: absolute;
+            inset: -40px -28px;
+            background: var(--bg-url) center / cover no-repeat;
+            opacity: .24;
+            filter: saturate(1.05) contrast(1.02);
+            border-radius: 26px;
+            z-index: -1;
+        }
         .chip-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 6px }
         .chip { background: #e8f0ff; color: #1b3159; padding: 6px 10px; border-radius: 999px; border: 1px solid rgba(20,40,72,.12) }
         .hl { color: var(--brand) }


### PR DESCRIPTION
## Summary
- add a dedicated hero background layer tied to the randomized background variable
- ensure hero section isolates its background so imagery reliably appears

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e201ee744832d9fdb05cbe7dbd740)

## Summary by Sourcery

Restore the hero section’s background imagery using the shared randomized background and ensure it renders reliably behind the hero content.

Enhancements:
- Add a pseudo-element background layer to the hero section tied to the global background image variable.
- Update the hero container styling to isolate and correctly layer its background imagery behind foreground content.