### PR TITLE
Add founder introduction strip under hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,11 +557,55 @@
         .card ul { padding-left: 18px; margin: 8px 0 }
         .mono { font-family: "Roboto Mono", ui-monospace, Menlo, Consolas, monospace }
 
+        .founder-section {
+            position: relative;
+            padding: 32px 0;
+            background: var(--bg);
+            isolation: isolate;
+        }
+
+        .founder-section::before {
+            content: "";
+            position: absolute;
+            inset: -30px -20px;
+            background: var(--bg-url) center / cover no-repeat;
+            opacity: .18;
+            filter: saturate(1.05) contrast(1.02);
+            z-index: -1;
+            border-radius: 24px;
+        }
+
+        .founder-inner {
+            width: var(--container);
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+        }
+
+        .founder-avatar {
+            width: clamp(96px, 12vw, 128px);
+            height: auto;
+            border-radius: 9999px;
+            box-shadow: 0 10px 28px rgba(12,22,44,0.16);
+            border: 2px solid rgba(20,40,72,.1);
+            background: rgba(255,255,255,.92);
+        }
+
+        .founder-copy h3 { margin: 0 0 6px; font-size: clamp(18px, 2.2vw, 22px); }
+        .founder-copy p { margin: 0 0 8px; color: var(--text); }
+
+        @media (max-width: 720px) {
+            .founder-inner {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+        }
+
         .founder-card { display: grid; gap: 16px; grid-template-columns: minmax(0, 1fr); align-items: center; background: linear-gradient(135deg, rgba(255,77,0,.05), rgba(15,99,255,.05)); }
         .founder-card img { width: 100%; max-width: 320px; border-radius: 14px; box-shadow: 0 10px 28px rgba(12,22,44,0.16); }
         .founder-card figure { margin: 0; display: grid; gap: 10px; justify-items: start; }
         .founder-caption { font-size: 14px; color: var(--muted); }
-        .founder-copy p { margin: 0; color: var(--text); }
         @media (min-width: 780px) {
             .founder-card { grid-template-columns: 320px 1fr; }
         }
@@ -896,6 +940,30 @@
                 <div id="typeBody" class="muted mono"></div>
                 <div class="mono" id="typeCaret" style="color:var(--text-strong)"><span class="caret"></span></div>
             </article>
+        </section>
+
+        <section id="founder-intro" class="founder-section" aria-label="Founder introduction">
+            <div class="founder-inner">
+                <img
+                    src="/assets/founder/Thomas_Nelson_Founder.png"
+                    alt="Thomas Nelson, founder of Cerbi"
+                    class="founder-avatar"
+                />
+                <div class="founder-copy">
+                    <h3>Built by a principal architect, not a marketing team</h3>
+                    <p>
+                        I’m Tom, a principal architect who’s spent years untangling .NET logging
+                        in regulated environments — healthcare, payments, and cloud platforms that
+                        actually get audited. Cerbi is the logging and governance layer I kept
+                        sketching on whiteboards and never got from vendors, so I built it.
+                    </p>
+                    <p>
+                        CerbiStream runs in your .NET services. CerbiShield runs in your tenant.
+                        You keep your log sinks. Cerbi gives you governed, PII-safe, audit-ready
+                        telemetry without dropping another black-box SaaS in the middle.
+                    </p>
+                </div>
+            </div>
         </section>
 
         <!-- Signature Art Rotator -->


### PR DESCRIPTION
## Summary
- add a founder introduction section under the hero with founder portrait and story
- style the new strip to share the hero background and responsive layout with avatar and copy

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e737b69d4832db57827ee8ca9e2fd)

## Summary by Sourcery

Introduce a founder introduction strip beneath the hero with matching visual treatment and responsive layout.

New Features:
- Add a founder introduction section featuring the founder’s portrait and story below the hero area.

Enhancements:
- Style the founder introduction strip to share the hero background aesthetic and support responsive alignment of avatar and copy.