### PR TITLE
Clean up placeholder artifacts on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1823,7 +1823,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
             <!-- Expandable detail panel -->
             <div id="repoDetail" class="repo-detail-panel" hidden>
-                <button class="repo-detail-close" aria-label="Close details">✕</button>
+                <button class="repo-detail-close" aria-label="Close details">Close</button>
                 <div class="repo-detail-content">
                     <div class="repo-detail-header">
                         <div class="repo-detail-icon"></div>
@@ -2986,7 +2986,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             <div id="videoModal" class="video-modal" hidden>
                 <div class="video-modal-backdrop"></div>
                 <div class="video-modal-content">
-                    <button class="video-modal-close" aria-label="Close video">✕</button>
+                    <button class="video-modal-close" aria-label="Close video">Close</button>
                     <div class="video-modal-player">
                         <video id="modalVideo" controls playsinline>
                             <source src="" type="video/mp4" />
@@ -3005,7 +3005,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             <div class="eyebrow">Vision</div>
             <h2>Why I Built CerbiSuite</h2>
             <p class="lead">A candid walkthrough for leaders and architects on where Cerbi fits: what problem it solves, what it doesn’t do, and how it plugs into the stack you already have.</p>
-            <p class="note"><strong>If the video is not implemented yet, show this text:</strong> <em>Video walkthrough coming soon. For now, scroll up for the architecture diagram and ecosystem overview.</em></p>
+            <p class="note">Video walkthrough coming soon. For now, scroll up for the architecture diagram and ecosystem overview.</p>
             <div class="card" style="padding:16px;">
                 <div class="video-container">
                     <video controls preload="metadata" playsinline>
@@ -3326,7 +3326,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
     </footer>
 
     <div id="lightbox" class="lightbox" aria-hidden="true" hidden>
-        <button class="close" aria-label="Close preview">✕</button>
+        <button class="close" aria-label="Close preview">Close</button>
         <img id="lightboxImg" alt="" />
     </div>
 


### PR DESCRIPTION
## Summary
- remove stray placeholder close icons on the landing page modals
- replace the Vision section instruction note with a user-facing fallback message

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693070d25260832db0e57af459584915)

## Summary by Sourcery

Clean up placeholder UI artifacts on the homepage and improve the Vision section fallback copy.

Enhancements:
- Replace decorative close icons with text labels on repo detail, video modal, and lightbox controls for clearer UI and accessibility.
- Update the Vision section note to a user-facing fallback message describing the upcoming video walkthrough.