### PR TITLE
Improve ecosystem stage scroll syncing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1733,7 +1733,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </div>
 
                     <div class="pipeline-stacks">
-                    <div class="pipeline-stack" data-stage="overview">
+                        <div class="pipeline-stack" data-stage="overview" id="ecosystem-stage-overview">
                         <div class="stack-header">
                             <p class="stage-label">Overview</p>
                             <h3 class="stack-title">Ecosystem overview</h3>


### PR DESCRIPTION
## Summary
- add an anchor id for the ecosystem overview stack to support scroll tracking
- update the scroll spy to use IntersectionObserver, smooth scrolling, and active stage syncing
- keep the stage selector highlighting aligned with scrolled content while remaining sticky on desktop

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307fa8037c832da4359d219c2e0355)

## Summary by Sourcery

Improve scroll spy behavior for the ecosystem stages so that active stage highlighting stays in sync with the scrolled content and supports the overview stack.

New Features:
- Support smooth scrolling to ecosystem stages when clicking stage selector buttons.
- Track the ecosystem overview stack as part of the stage-based scroll spy behavior.

Bug Fixes:
- Ensure the sticky stage selector highlight accurately reflects the section currently in view, including the overview section.

Enhancements:
- Use IntersectionObserver with tuned thresholds and root margins to determine the active stage based on visible sections.
- Keep the active stage state in sync via a ref to avoid stale updates during scroll observation.