### PR TITLE
Simplify ecosystem section background layers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1892,11 +1892,27 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
         </section>
 
         <style>
-        /* Ecosystem pipeline layout */
+            /* Ecosystem pipeline layout */
             .repo-ecosystem {
                 display: block;
                 margin: 40px 0;
                 padding-bottom: 96px;
+                position: relative;
+                isolation: isolate;
+            }
+
+            .repo-ecosystem::before {
+                content: "";
+                position: absolute;
+                inset: -22px;
+                background:
+                    radial-gradient(circle at 18% 14%, rgba(255,77,0,.06), transparent 42%),
+                    radial-gradient(circle at 82% 6%, rgba(15,99,255,.05), transparent 44%),
+                    linear-gradient(180deg, rgba(255,255,255,.96), rgba(255,255,255,.98));
+                border-radius: 26px;
+                box-shadow: 0 18px 48px rgba(10,16,30,.10);
+                z-index: -1;
+                pointer-events: none;
             }
 
             .pipeline-layout-grid {
@@ -2133,6 +2149,13 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             @media (max-width: 900px) {
                 .pipeline-column {
                     max-width: 100%;
+                }
+            }
+
+            @media (max-width: 768px) {
+                .repo-ecosystem::before {
+                    inset: -14px;
+                    border-radius: 20px;
                 }
             }
 


### PR DESCRIPTION
## Summary
- add an isolated gradient wrapper behind the "Explore the Cerbi Ecosystem" section to mask the extra stacked background artwork
- tune the pseudo-element inset on smaller screens so the backdrop stays aligned on mobile

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930824b8ae0832d8e638eb6ebe21ac5)

## Summary by Sourcery

Introduce an isolated, styled background wrapper for the ecosystem section to contain and align decorative artwork across viewports.

Enhancements:
- Add a pseudo-element background layer to the ecosystem section to encapsulate gradient and shadow styling.
- Adjust responsive insets and border radius for the ecosystem background wrapper to maintain visual alignment on mobile.