### PR TITLE
Fix Explore stage layout spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1738,7 +1738,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <p class="stage-label">Overview</p>
                             <h3 class="stack-title">Ecosystem overview</h3>
                         </div>
-                        <div class="stack-grid">
+                        <div class="stack-list">
                             <button type="button" class="repo-node" data-repo="suite">
                                 <div class="repo-icon">🧭</div>
                                 <h4 class="repo-name">CerbiSuite</h4>
@@ -1757,7 +1757,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <p class="stage-label">Stage 1</p>
                             <h3 class="stack-title">Source logging</h3>
                         </div>
-                        <div class="stack-grid">
+                        <div class="stack-list">
                             <button type="button" class="repo-node" data-repo="cerbistream">
                                 <div class="repo-icon">🚀</div>
                                 <h4 class="repo-name">CerbiStream</h4>
@@ -1776,7 +1776,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <p class="stage-label">Stage 2</p>
                             <h3 class="stack-title">Build-time guardrails</h3>
                         </div>
-                        <div class="stack-grid">
+                        <div class="stack-list">
                             <button type="button" class="repo-node" data-repo="analyzer">
                                 <div class="repo-icon">🔍</div>
                                 <h4 class="repo-name">CerbiStream.GovernanceAnalyzer</h4>
@@ -1795,7 +1795,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <p class="stage-label">Stage 3</p>
                             <h3 class="stack-title">Runtime governance &amp; scoring</h3>
                         </div>
-                        <div class="stack-grid">
+                        <div class="stack-list">
                             <button type="button" class="repo-node" data-repo="mel">
                                 <div class="repo-icon">⚡</div>
                                 <h4 class="repo-name">Cerbi.MEL.Governance</h4>
@@ -1836,7 +1836,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <p class="stage-label">Stage 4</p>
                             <h3 class="stack-title">Shared contracts</h3>
                         </div>
-                        <div class="stack-grid">
+                        <div class="stack-list">
                             <button type="button" class="repo-node" data-repo="core">
                                 <div class="repo-icon">⚙️</div>
                                 <h4 class="repo-name">Cerbi.Governance.Core</h4>
@@ -1855,7 +1855,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                             <p class="stage-label">Stage 5</p>
                             <h3 class="stack-title">Dashboards &amp; reporting</h3>
                         </div>
-                        <div class="stack-grid">
+                        <div class="stack-list">
                             <button type="button" class="repo-node" data-repo="shield">
                                 <div class="repo-icon">🛡️</div>
                                 <h4 class="repo-name">CerbiShield</h4>
@@ -2129,9 +2129,9 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 color: var(--text-strong);
             }
 
-            .stack-grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            .stack-list {
+                display: flex;
+                flex-direction: column;
                 gap: 12px;
             }
 


### PR DESCRIPTION
## Summary
- updated Explore pipeline stacks to use consistent vertical spacing
- ensured runtime governance cards are fully visible without clipping

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930875b0390832d94a6218a27d82c6a)

## Summary by Sourcery

Enhancements:
- Standardize Explore pipeline stack containers to use a columnar list layout for more consistent vertical spacing across stages.