### PR TITLE
Align CerbiStream .NET version messaging

### DIFF
--- a/index-current.html
+++ b/index-current.html
@@ -724,7 +724,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
       <ul style="margin:10px 0">
         <li><strong>Features:</strong> Structured JSON logs, AES/Base64 encryption, <code>WithFileFallback()</code>, live profile reload</li>
         <li><strong>Governance:</strong> Required/Forbidden fields, redaction, tagging, relax-mode bypass</li>
-        <li><strong>Compatibility:</strong> .NET 6/7/8; Serilog/NLog/MEL via adapters</li>
+        <li><strong>Compatibility:</strong> .NET 8–9 (compatible with .NET 10+); Serilog/NLog/MEL via adapters</li>
       </ul>
 
       <details class="glass" style="padding:12px;border-radius:12px">

--- a/index-draft.html
+++ b/index-draft.html
@@ -1598,7 +1598,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
                 <div id="oss-1" class="oss-panel" hidden>
                     <ul class="oss-details">
-                        <li><strong>Status:</strong> Active; .NET 6–8.</li>
+                        <li><strong>Status:</strong> GA; targets .NET 8–9 (compatible with .NET 10+).</li>
                         <li><strong>Highlights:</strong> Channel&lt;T&gt; async path, file fallback + encrypted rotation, governance hooks (<code>[CerbiTopic]</code>, <code>.Relax()</code>), redaction/violation tags, queue-first routing.</li>
                         <li><strong>Companions:</strong> Governance runtime + analyzers.</li>
                     </ul>

--- a/index.html
+++ b/index.html
@@ -1285,7 +1285,12 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     <tbody>
                         <tr>
                             <td><strong>CerbiStream</strong></td>
-                            <td><span class="chip">GA</span></td>
+                            <td>
+                                <div class="repo-status">
+                                    <span class="badge badge-ga">GA</span>
+                                    <span class="badge badge-net">.NET 8–9 (compatible with .NET 10+)</span>
+                                </div>
+                            </td>
                             <td>Core .NET logger with structured output and optional encryption. Works with governance analyzers (build-time) and runtime validators.</td>
                         </tr>
                         <tr>


### PR DESCRIPTION
## Summary
- Update CerbiStream status badge in the ecosystem table to show .NET 8–9 (compatible with .NET 10+) in line with NuGet targets
- Refresh CerbiStream compatibility copy in legacy pages to reflect the same .NET support wording

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308ab8d9dc832d95d38958f71bff00)

## Summary by Sourcery

Align CerbiStream .NET support messaging across ecosystem and legacy pages to reflect current target frameworks.

Enhancements:
- Update the CerbiStream ecosystem table to display GA status alongside .NET 8–9 (compatible with .NET 10+) support.
- Refresh CerbiStream compatibility and status copy in current and draft pages to consistently describe .NET 8–9 targeting and .NET 10+ compatibility.