### PR TITLE
Center persona section and add spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -560,9 +560,9 @@
 
         .scroll-target { scroll-margin-top: calc(var(--nav-h) + 16px); }
 
-        .persona-nav { padding: 16px 0 20px; margin: 18px 0 14px; }
-        .persona-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
-        .persona-card { text-decoration: none; color: inherit; display: grid; gap: 6px; align-content: start; padding: 14px 16px; border-radius: 14px; border: 1px solid rgba(20,40,72,.12); background: linear-gradient(135deg, rgba(255,77,0,.06), rgba(15,99,255,.04)); box-shadow: 0 14px 36px rgba(12,22,44,0.08); transition: transform .15s ease, box-shadow .2s ease, border-color .2s ease; }
+        .persona-nav { padding: 40px 0; margin: 32px auto; text-align: center; }
+        .persona-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; justify-items: center; }
+        .persona-card { text-decoration: none; color: inherit; display: grid; gap: 6px; align-content: start; padding: 16px 18px; border-radius: 14px; border: 1px solid rgba(20,40,72,.12); background: linear-gradient(135deg, rgba(255,77,0,.06), rgba(15,99,255,.04)); box-shadow: 0 14px 36px rgba(12,22,44,0.08); transition: transform .15s ease, box-shadow .2s ease, border-color .2s ease; max-width: 360px; width: 100%; }
         .persona-card:hover { transform: translateY(-1px); box-shadow: 0 18px 44px rgba(12,22,44,0.12); border-color: color-mix(in srgb, var(--brand) 30%, rgba(20,40,72,.12)); }
         .persona-title { font-weight: 800; font-size: 16px; color: var(--text-strong); }
         .persona-desc { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.45; }


### PR DESCRIPTION
## Summary
- center the persona navigation tiles within the page layout and constrain their width
- add vertical padding and margin to provide breathing room between neighboring sections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930949abd80832daa3d837978218856)