### PR TITLE
Align ecosystem stage targets

### DIFF
--- a/index.html
+++ b/index.html
@@ -1680,7 +1680,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                 <div class="pipeline-stage-highlight" aria-hidden="true"></div>
                                 <ol class="pipeline-stages" aria-label="Cerbi pipeline stages">
                                     <li class="pipeline-stage-row">
-                                        <button type="button" class="pipeline-stage" data-stage="1">
+                                        <button type="button" class="pipeline-stage" data-stage="1" data-target="ecosystem-stage-1">
                                             <div class="stage-number" aria-hidden="true">1</div>
                                             <div class="stage-copy">
                                                 <p class="stage-kicker">Stage 1</p>
@@ -1689,7 +1689,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                         </button>
                                     </li>
                                     <li class="pipeline-stage-row">
-                                        <button type="button" class="pipeline-stage" data-stage="2">
+                                        <button type="button" class="pipeline-stage" data-stage="2" data-target="ecosystem-stage-2">
                                             <div class="stage-number" aria-hidden="true">2</div>
                                             <div class="stage-copy">
                                                 <p class="stage-kicker">Stage 2</p>
@@ -1698,7 +1698,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                         </button>
                                     </li>
                                     <li class="pipeline-stage-row">
-                                        <button type="button" class="pipeline-stage" data-stage="3">
+                                        <button type="button" class="pipeline-stage" data-stage="3" data-target="ecosystem-stage-3">
                                             <div class="stage-number" aria-hidden="true">3</div>
                                             <div class="stage-copy">
                                                 <p class="stage-kicker">Stage 3</p>
@@ -1707,7 +1707,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                         </button>
                                     </li>
                                     <li class="pipeline-stage-row">
-                                        <button type="button" class="pipeline-stage" data-stage="4">
+                                        <button type="button" class="pipeline-stage" data-stage="4" data-target="ecosystem-stage-4">
                                             <div class="stage-number" aria-hidden="true">4</div>
                                             <div class="stage-copy">
                                                 <p class="stage-kicker">Stage 4</p>
@@ -1716,7 +1716,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                                         </button>
                                     </li>
                                     <li class="pipeline-stage-row">
-                                        <button type="button" class="pipeline-stage" data-stage="5">
+                                        <button type="button" class="pipeline-stage" data-stage="5" data-target="ecosystem-stage-5">
                                             <div class="stage-number" aria-hidden="true">5</div>
                                             <div class="stage-copy">
                                                 <p class="stage-kicker">Stage 5</p>

--- a/scripts/ecosystem-scrollspy.js
+++ b/scripts/ecosystem-scrollspy.js
@@ -18,13 +18,15 @@
         ];
 
         const sectionStageLookup = new Map(stageSections.map(({ id, stage }) => [id, stage]));
-        const stageTargetLookup = new Map([
-            [1, 'ecosystem-stage-1'],
-            [2, 'ecosystem-stage-2'],
-            [3, 'ecosystem-stage-3'],
-            [4, 'ecosystem-stage-4'],
-            [5, 'ecosystem-stage-5']
-        ]);
+        const stageTargetLookup = new Map(
+            Array.from({ length: 5 }, (_, idx) => [idx + 1, `ecosystem-stage-${idx + 1}`])
+        );
+
+        const getStageTargetId = (stageNumber) => {
+            const button = document.querySelector(`.pipeline-stage[data-stage="${stageNumber}"]`);
+            const dataTarget = button?.dataset?.target;
+            return dataTarget || stageTargetLookup.get(stageNumber);
+        };
 
         const moveHighlight = (stageValue) => {
             const highlight = document.querySelector('.pipeline-stage-highlight');
@@ -100,7 +102,7 @@
                 const stageNumber = parseInt(targetButton.dataset.stage || '', 10);
                 if (Number.isNaN(stageNumber)) return;
 
-                const targetId = stageTargetLookup.get(stageNumber);
+                const targetId = getStageTargetId(stageNumber);
                 const target = targetId ? document.getElementById(targetId) : null;
 
                 if (target) {
@@ -138,7 +140,7 @@
             buttons.forEach((btn) => {
                 const stageNumber = parseInt(btn.dataset.stage || '', 10);
                 const isActive = stageNumber === activeStage;
-                const targetId = stageTargetLookup.get(stageNumber);
+                const targetId = getStageTargetId(stageNumber);
 
                 btn.classList.toggle('is-active', isActive);
                 if (targetId) {


### PR DESCRIPTION
## Summary
- add explicit data-target ids to ecosystem stage buttons so labels and sections stay in sync
- update scrollspy logic to read the declared targets while keeping stable fallback ids

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930a3c52b0c832db3dad1efb735d608)