### PR TITLE
Increase hero art height

### DIFF
--- a/index.html
+++ b/index.html
@@ -878,8 +878,8 @@
 
         /* Signature art rotator */
         .sig-outer { width: 100vw; margin-left: 50%; transform: translateX(-50%) }
-        .sig-rotator { min-height: clamp(340px, 52vw, 520px); position: relative; }
-        @media (min-width: 900px) { .sig-rotator { min-height: clamp(420px, 58vw, 620px); } }
+        .sig-rotator { min-height: clamp(380px, 58vw, 680px); position: relative; }
+        @media (min-width: 900px) { .sig-rotator { min-height: clamp(520px, 64vw, 760px); } }
         .sig-rotator img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; opacity: 0; visibility: hidden; transform: scale(1.02); transition: opacity .45s ease, visibility .45s ease, transform .6s ease }
         .sig-rotator img.is-active { opacity: 1; visibility: visible; transform: none }
 


### PR DESCRIPTION
## Summary
- raise the signature hero art rotator height to prevent images from being clipped on larger screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e39cfa6c832d9c22ec66fa594374)

## Summary by Sourcery

Enhancements:
- Adjust the responsive height constraints of the signature hero art rotator for better display on wide viewports.