### PR TITLE
Align marketing copy with governance and scoring narrative

### DIFF
--- a/index-current.html
+++ b/index-current.html
@@ -580,7 +580,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             <tr><td><strong>CerbiStream</strong></td><td><span class="pill ok">GA</span></td><td>Core .NET logger with structured output, encryption, and governance</td></tr>
             <tr><td><strong>CerbiStream.GovernanceAnalyzer</strong></td><td><span class="pill ok">GA</span></td><td>Static/dynamic schema validator enforcing rules at build and runtime</td></tr>
             <tr><td><strong>CerbiShield</strong></td><td><span class="pill beta">Beta (SaaS soon)</span></td><td>Governance dashboard UI & enforcement engine</td></tr>
-            <tr><td><strong>CerbIQ</strong></td><td><span class="pill planned">Phase 2 Planned</span></td><td>Routing, normalization, and fan‑out for logs</td></tr>
+            <tr><td><strong>Scoring API</strong></td><td><span class="pill planned">Phase 2 Planned</span></td><td>Governance scores for coverage, violations, redaction posture, and risk</td></tr>
             <tr><td><strong>CerbiSense</strong></td><td><span class="pill planned">Phase 2 Planned</span></td><td>ML‑driven anomaly detection and trend forecasting</td></tr>
           </tbody>
         </table>
@@ -898,7 +898,7 @@ dotnet add package Cerbi.Governance.Runtime
         <button class="filter" data-tag="build">Build‑time</button>
         <button class="filter" data-tag="runtime">Runtime</button>
         <button class="filter" data-tag="encryption">Encryption</button>
-        <button class="filter" data-tag="routing">Routing</button>
+        <button class="filter" data-tag="routing">Pipelines</button>
       </div>
       <div class="glass" style="padding:8px 12px;overflow-x:auto">
         <table aria-label="Logger comparison table" id="compareTable">
@@ -908,8 +908,8 @@ dotnet add package Cerbi.Governance.Runtime
             <tr data-tags="runtime"><td>Runtime Governance Enforcement</td><td>❌ Not applicable</td><td>✅ Via <span class="kbd">Cerbi.Serilog.GovernanceAnalyzer</span></td></tr>
             <tr data-tags="encryption"><td>Encryption Support (AES, Base64)</td><td>✅ Built‑in</td><td>❌ Not included</td></tr>
             <tr data-tags="routing"><td>File Fallback Logging</td><td>✅ <span class="kbd">WithFileFallback()</span></td><td>✅ via <span class="kbd">Serilog.Sinks.File</span></td></tr>
-            <tr data-tags="routing"><td>Telemetry Routing & Enrichment</td><td>✅ Built‑in (App Insights, OTel)</td><td>✅ Supported via Serilog sinks & enrichers</td></tr>
-            <tr data-tags="routing"><td>ML / CerbIQ Compatibility</td><td>✅ Schema‑aligned automatically</td><td>✅ Requires matching metadata (CerbiShield assists)</td></tr>
+            <tr data-tags="routing"><td>Routing to vendors</td><td>Customer pipelines (OTel, Fluent Bit, Vector, custom) move data; CerbiStream governs payloads at the source</td><td>Customer pipelines (Serilog sinks, OTel) move data; the plugin enforces governance metadata</td></tr>
+            <tr data-tags="routing"><td>Scoring API Compatibility</td><td>✅ Schema‑aligned automatically for governance scoring</td><td>✅ Requires matching metadata (CerbiShield assists)</td></tr>
             <tr data-tags="build runtime"><td>Governance Profile Reloading</td><td>✅ Supported</td><td>✅ Supported</td></tr>
             <tr data-tags="build runtime"><td>Custom Rule Plugins</td><td>✅ Supported</td><td>✅ via <span class="kbd">ICustomGovernancePlugin</span></td></tr>
             <tr data-tags="routing"><td>App Rollup / Grouping Support</td><td>✅ Built‑in</td><td>⚠️ External design needed</td></tr>
@@ -945,13 +945,13 @@ dotnet add package Cerbi.Governance.Runtime
   ▼
 CerbiShield Plugin / Analyzer (Required / Forbidden Field Enforcement)
   │
-  ├──▶ Logs go to your standard sinks (console, file, Splunk, etc.)
+  ├──▶ Logs go to your standard sinks via OTel / Fluent Bit / Vector / custom pipelines
   │
-  └──▶ (optional) CerbiStream → CerbIQ → CerbiSense (Phase 2)
+  └──▶ (optional) CerbiStream → Scoring API → CerbiSense (Phase 2)
               │        │
               ▼        ▼
          Governance    ML Analytics
-         Routing       Scoring & Trends</code></pre>
+         Scores        Scoring & Trends</code></pre>
           <button class="btn" data-copy="#architecture code">Copy</button>
         </div>
         <div class="col-6 glass tilt" style="padding:16px">

--- a/index-draft.html
+++ b/index-draft.html
@@ -1512,7 +1512,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Keep your sinks</h3>
                     <ul>
-                        <li><strong>Splunk / ELK / OpenSearch / Datadog / CloudWatch:</strong> send less, cleaner data.</li>
+                        <li><strong>Splunk / ELK / OpenSearch / Datadog / CloudWatch:</strong> CerbiStream governs at the source while you keep routing via OTel, Fluent Bit, Vector, or your own collectors.</li>
                         <li><strong>Durable dashboards:</strong> governed field names/types avoid chart breakage.</li>
                         <li><strong>ML-ready:</strong> consistent, PII-safe features feed analytics/LLMs.</li>
                     </ul>
@@ -1625,7 +1625,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <div id="oss-1" class="oss-panel" hidden>
                     <ul class="oss-details">
                         <li><strong>Status:</strong> GA; targets .NET 8–9 (compatible with .NET 10+).</li>
-                        <li><strong>Highlights:</strong> Channel&lt;T&gt; async path, file fallback + encrypted rotation, governance hooks (<code>[CerbiTopic]</code>, <code>.Relax()</code>), redaction/violation tags, queue-first routing.</li>
+                        <li><strong>Highlights:</strong> Channel&lt;T&gt; async path, file fallback + encrypted rotation, governance hooks (<code>[CerbiTopic]</code>, <code>.Relax()</code>), redaction/violation tags, queue-first buffering.</li>
                         <li><strong>Companions:</strong> Governance runtime + analyzers.</li>
                     </ul>
                 </div>
@@ -1911,7 +1911,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>CerbIQ — routing, normalization, rollups, fan-out</li>
+                        <li>Scoring API — governance scores for coverage, violations, redaction posture, and risk</li>
                         <li>CerbiSense — ML anomaly detection & trend forecasting</li>
                         <li>Marketplace integrations (Azure/AWS/GCP)</li>
                     </ul>

--- a/index.html
+++ b/index.html
@@ -1289,7 +1289,7 @@
                 <div class="security-card">
                     <div class="security-icon">📊</div>
                     <h3>Real-Time Violation Alerts</h3>
-                    <p>Catch governance violations quickly. Cerbi tags events with structured violations you can route into your existing alert stack (Splunk, Datadog, ELK, Grafana, etc.) so issues surface before they turn into incidents or audit findings.</p>
+                    <p>Catch governance violations quickly. Cerbi tags events with structured violations so your pipelines (OTel, Fluent Bit, Vector, custom collectors) can forward alerts into your existing stack (Splunk, Datadog, ELK, Grafana, etc.) before issues become incidents or audit findings.</p>
                 </div>
 
                 <div class="security-card">
@@ -1649,8 +1649,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <li>Apps & services emit events</li>
                         <li>Build-time analyzers catch schema/PII violations pre-merge</li>
                         <li>Runtime validators redact/flag (relax-mode to roll out safely)</li>
-                        <li>CerbiShield hosts versioned profiles, RBAC, audit history</li>
-                        <li>Downstream sinks receive clean, consistent data</li>
+                        <li>CerbiShield hosts versioned profiles, RBAC, audit history, and deployable policy</li>
+                        <li>Teams route governed events through OTel, Fluent Bit, Vector, or custom pipelines to their sinks; Cerbi never ships your logs to vendors</li>
                     </ul>
                 </article>
                 <figure class="col-6 img-frame arch-diagram card" style="padding:10px">
@@ -1680,7 +1680,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Keep your sinks</h3>
                     <ul>
-                        <li><strong>Splunk / ELK / OpenSearch / Datadog / CloudWatch:</strong> send less, cleaner data.</li>
+                        <li><strong>Splunk / ELK / OpenSearch / Datadog / CloudWatch:</strong> CerbiStream governs at the source while you keep routing via OTel, Fluent Bit, Vector, or your own collectors.</li>
                         <li><strong>Durable dashboards:</strong> governed field names/types avoid chart breakage.</li>
                         <li><strong>ML-ready:</strong> consistent, PII-safe features feed analytics/LLMs.</li>
                     </ul>
@@ -2994,7 +2994,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>CerbIQ — routing, normalization, rollups, fan-out</li>
+                        <li>Scoring API — governance scores for coverage, violations, redaction posture, and risk</li>
                         <li>CerbiSense — ML anomaly detection & trend forecasting</li>
                         <li>Marketplace integrations (Azure/AWS/GCP)</li>
                     </ul>
@@ -4509,7 +4509,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         'File fallback with encrypted rotation',
                         'Governance hooks: [CerbiTopic] attributes, .Relax() mode',
                         'Redaction & violation tagging',
-                        'Queue-first routing with configurable batching'
+                        'Queue-first buffering with configurable batching'
                     ],
                     github: 'https://github.com/Zeroshi/Cerbi-CerbiStream',
                     nuget: 'https://www.nuget.org/packages/CerbiStream',

--- a/oldmdfile
+++ b/oldmdfile
@@ -39,7 +39,7 @@ CerbiSuite is a cohesive suite of tools, each addressing a critical aspect of en
 | **CerbiStream**                    | GA               | Core .NET logger with structured output, encryption, and governance  |
 | **CerbiStream.GovernanceAnalyzer** | GA               | Static/dynamic schema validator enforcing rules at build and runtime |
 | **CerbiShield**                    | Beta (SaaS Soon) | Governance dashboard UI & enforcement engine                         |
-| **CerbIQ**                         | Phase 2 Planned  | Routing, normalization, and fan-out engine for logs                  |
+| **Scoring API**                    | Phase 2 Planned  | Governance scores for coverage, violations, redaction posture, and risk |
 | **CerbiSense**                     | Phase 2 Planned  | ML-driven anomaly detection and trend forecasting from metadata      |
 
 ---
@@ -65,13 +65,13 @@ This makes Cerbi governance **logger-agnostic**. It is not centered around Cerbi
 
 Cerbi was built to meet teams where they are—whether you’re managing legacy services with **Serilog** or modernizing with **CerbiStream**.
 
-You're absolutely right—**Serilog** **does** support telemetry routing and enrichment via widely used sinks and enrichers, including:
+Cerbi does **not** route logs to vendors. Teams keep their existing transport choices—Serilog sinks, OpenTelemetry collectors, Fluent Bit, Vector, or custom shippers—and CerbiStream/Serilog governance plugins focus on source enforcement and metadata.
 
 - `Serilog.Sinks.ApplicationInsights`
 - `Serilog.Sinks.OpenTelemetry`
 - `Serilog.Enrichers.*` for machine name, thread ID, and more
 
-It may not be **built-in** to the governance plugin, but it’s fully **supported** in the Serilog ecosystem—just like encryption and file fallback.
+Routing and enrichment stay in your control; governance travels with the payload.
 
 Also, great callout: **CerbiStream** has **built-in rollup and grouping support** (e.g., for multi-app environments reporting to a single governance score), which is important for CerbiShield’s analytics pipeline.
 
@@ -89,8 +89,8 @@ Cerbi governance works with both modern and established logging frameworks. Whet
 | **Runtime Governance Enforcement**    | ❌ Not applicable                   | ✅ Via `Cerbi.Serilog.GovernanceAnalyzer`           |
 | **Encryption Support (AES, Base64)**  | ✅ Built-in                         | ❌ Not included                                     |
 | **File Fallback Logging**             | ✅ `WithFileFallback()` available   | ✅ Supported via `Serilog.Sinks.File`               |
-| **Telemetry Routing & Enrichment**    | ✅ Built-in (App Insights, OTel)    | ✅ Supported via Serilog sinks & enrichers          |
-| **ML / CerbIQ Compatibility**         | ✅ Schema-aligned automatically     | ✅ Requires matching metadata (CerbiShield assists) |
+| **Routing to vendors**                | Customer pipelines (OTel, Fluent Bit, Vector, custom); CerbiStream governs at source | Customer pipelines (Serilog sinks, OTel); plugin enforces governance metadata |
+| **Scoring API Compatibility**         | ✅ Schema-aligned automatically for governance scoring     | ✅ Requires matching metadata (CerbiShield assists) |
 | **Governance Profile Reloading**      | ✅ Supported                        | ✅ Supported                                        |
 | **Custom Rule Plugins**               | ✅ Supported                        | ✅ Via `ICustomGovernancePlugin`                    |
 | **App Rollup / Grouping Support**     | ✅ Built-in                         | ⚠️ External design needed                          |
@@ -100,8 +100,8 @@ Cerbi governance works with both modern and established logging frameworks. Whet
 **Already on Serilog?**  
 You can adopt governance today using the Cerbi plugin — no need to rip out your existing logger.
 
-**Modernizing your platform?**  
-CerbiStream gives you structure, compliance, and full compatibility with future CerbIQ and CerbiSense tools—all enforced at build time for maximum control and performance.
+**Modernizing your platform?**
+CerbiStream gives you structure, compliance, and full compatibility with the Scoring API and CerbiSense—enforced at build time for maximum control and performance.
 
 > 🧩 CerbiShield governance works with both options — ensuring consistent enforcement regardless of your logging library.
 
@@ -125,7 +125,7 @@ This makes Cerbi ideal for:
 
 > **Need help preparing for GDPR or HIPAA audits?** CerbiShield includes compliance starter kits and audit-friendly profiles to jumpstart your governance baseline.
 
-> **Note:** Future components CerbIQ and CerbiSense will require logs to follow the CerbiStream-compatible JSON schema. If you use another logger, you must emit conforming metadata (`originApp`, `accessScope`, etc.).
+> **Note:** Future components (Scoring API and CerbiSense) will require logs to follow the CerbiStream-compatible JSON schema. If you use another logger, you must emit conforming metadata (`originApp`, `accessScope`, etc.).
 
 Whether you're using Serilog, NLog, MEL, or CerbiStream directly, CerbiShield provides the **business-critical layer** of control, compliance, and consistency.
 
@@ -139,10 +139,11 @@ Application (Serilog / NLog / MEL / CerbiStream)
         ▼
 CerbiShield Plugin / Analyzer (Required / Forbidden Field Enforcement)
         │
-        ├──▶ Logs go to your standard sinks (console, file, Splunk, etc.)
+        ├──▶ Logs go to your standard sinks via OTel / Fluent Bit / Vector / custom pipelines
         │
-        └──▶ (optional) CerbiStream → CerbIQ → CerbiSense (Phase 2)
+        └──▶ (optional) CerbiStream → Scoring API → CerbiSense (Phase 2)
                         │        │
                         ▼        ▼
                    Governance    ML Analytics
-                   Routing       Scoring & Trends
+                   Scores        Scoring & Trends
+```


### PR DESCRIPTION
## Summary
- Clarified that CerbiStream governs at the source while customers route telemetry through their own pipelines and sinks.
- Replaced legacy CerbIQ routing language with Scoring API governance scoring across site copies.
- Updated feature and architecture descriptions to highlight CerbiShield policy ownership and non-routing posture.

## Testing
- Not run (not requested)

## Changelog
- Clarified governance-and-scoring marketing narrative and customer-managed pipelines.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e6ff3360832da6958e825e1a4ca7)

## Summary by Sourcery

Align marketing copy to emphasize CerbiStream governance at the source, customer-owned telemetry pipelines, and the new Scoring API for governance scoring.

Enhancements:
- Replace legacy CerbIQ routing references with Scoring API governance scoring across ecosystem, comparison, architecture, and roadmap sections.
- Clarify that CerbiStream governs payloads at the source while customers retain control of routing via their own pipelines (OTel, Fluent Bit, Vector, custom collectors).
- Update copy to highlight CerbiShield’s policy ownership role and explicitly state that Cerbi does not ship logs to vendors, only governs them.
- Refine terminology around routing (e.g., routing vs pipelines, queue-first routing vs buffering) to better reflect the product’s non-routing posture and architecture.

Documentation:
- Refresh website and marketing copy to reflect governance-and-scoring narrative, customer-managed pipelines, and Scoring API positioning.