### PR TITLE
Align Scoring API messaging

### DIFF
--- a/index-current.html
+++ b/index-current.html
@@ -580,7 +580,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             <tr><td><strong>CerbiStream</strong></td><td><span class="pill ok">GA</span></td><td>Core .NET logger with structured output, encryption, and governance</td></tr>
             <tr><td><strong>CerbiStream.GovernanceAnalyzer</strong></td><td><span class="pill ok">GA</span></td><td>Static/dynamic schema validator enforcing rules at build and runtime</td></tr>
             <tr><td><strong>CerbiShield</strong></td><td><span class="pill beta">Beta (SaaS soon)</span></td><td>Governance dashboard UI & enforcement engine</td></tr>
-            <tr><td><strong>Scoring API</strong></td><td><span class="pill planned">Phase 2 Planned</span></td><td>Governance scores for coverage, violations, redaction posture, and risk</td></tr>
+            <tr><td><strong>Scoring API</strong></td><td><span class="pill planned">Phase 2 Planned</span></td><td>Governance signal normalization + scoring engine for coverage, violations, redaction posture, and risk</td></tr>
             <tr><td><strong>CerbiSense</strong></td><td><span class="pill planned">Phase 2 Planned</span></td><td>ML‑driven anomaly detection and trend forecasting</td></tr>
           </tbody>
         </table>
@@ -947,7 +947,7 @@ CerbiShield Plugin / Analyzer (Required / Forbidden Field Enforcement)
   │
   ├──▶ Logs go to your standard sinks via OTel / Fluent Bit / Vector / custom pipelines
   │
-  └──▶ (optional) CerbiStream → Scoring API → CerbiSense (Phase 2)
+  └──▶ (optional) CerbiStream → Scoring API (governance signal normalization + scoring engine) → CerbiSense (Phase 2)
               │        │
               ▼        ▼
          Governance    ML Analytics

--- a/index-draft.html
+++ b/index-draft.html
@@ -1911,7 +1911,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>Scoring API — governance scores for coverage, violations, redaction posture, and risk</li>
+                        <li>Scoring API — governance signal normalization + scoring engine for coverage, violations, redaction posture, and risk</li>
                         <li>CerbiSense — ML anomaly detection & trend forecasting</li>
                         <li>Marketplace integrations (Azure/AWS/GCP)</li>
                     </ul>

--- a/index.html
+++ b/index.html
@@ -1505,9 +1505,11 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             <ol class="card" style="padding:18px 22px; display:grid; gap:12px;">
                 <li><strong>Define policies (CerbiShield)</strong>: set required fields, redaction rules, and relax modes as versioned standards.</li>
                 <li><strong>Enforce at source (CerbiStream)</strong>: analyzers and runtime validators stop drift before data leaves the service.</li>
-                <li><strong>Score outcomes (Scoring API)</strong>: every event receives an impact score that highlights governance quality and risk.</li>
+                <li><strong>Score outcomes (Scoring API)</strong>: governance signals are normalized and every event is scored so risk and coverage are comparable across teams.</li>
                 <li><strong>Improve standards over time</strong>: scorecards feed back into CerbiShield so teams can tighten policies without breaking pipelines.</li>
             </ol>
+
+            <p class="muted">The Scoring API is the governance signal normalization + scoring engine; the legacy “CerbIQ” metadata router now lives here.</p>
 
             <p>Cerbi is not a transport layer—it layers governance and scoring on top of your existing choices. Customers keep their current pipelines and routing (Kafka, Event Hubs, HTTP collectors, or anything else) while Cerbi standardizes the payloads and enforcement.</p>
 
@@ -3014,7 +3016,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>Scoring API — governance scores for coverage, violations, redaction posture, and risk</li>
+                        <li>Scoring API — governance signal normalization + scoring engine for coverage, violations, redaction posture, and risk</li>
                         <li>CerbiSense — ML anomaly detection & trend forecasting</li>
                         <li>Marketplace integrations (Azure/AWS/GCP)</li>
                     </ul>

--- a/oldmdfile
+++ b/oldmdfile
@@ -39,7 +39,7 @@ CerbiSuite is a cohesive suite of tools, each addressing a critical aspect of en
 | **CerbiStream**                    | GA               | Core .NET logger with structured output, encryption, and governance  |
 | **CerbiStream.GovernanceAnalyzer** | GA               | Static/dynamic schema validator enforcing rules at build and runtime |
 | **CerbiShield**                    | Beta (SaaS Soon) | Governance dashboard UI & enforcement engine                         |
-| **Scoring API**                    | Phase 2 Planned  | Governance scores for coverage, violations, redaction posture, and risk |
+| **Scoring API**                    | Phase 2 Planned  | Governance signal normalization + scoring engine for coverage, violations, redaction posture, and risk |
 | **CerbiSense**                     | Phase 2 Planned  | ML-driven anomaly detection and trend forecasting from metadata      |
 
 ---


### PR DESCRIPTION
## Summary
- update Scoring API descriptions to highlight governance signal normalization and scoring engine role
- note that the legacy CerbIQ metadata router is now consolidated into the Scoring API
- refresh roadmap, diagrams, and supporting docs to match the new positioning

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932eb9d2e6c832db2588df4babc069d)

## Summary by Sourcery

Align marketing and architecture docs to position the Scoring API as the central governance signal normalization and scoring engine within the Cerbi ecosystem.

Enhancements:
- Clarify Scoring API messaging to emphasize governance signal normalization and cross-team comparable scoring.
- Update ecosystem and roadmap descriptions to reflect the Scoring API’s consolidated role, including the legacy CerbIQ metadata router.
- Refresh architecture flow text to show the Scoring API as the normalization and scoring stage between CerbiStream and CerbiSense.

Documentation:
- Revise product copy and roadmap entries across HTML pages to describe the Scoring API as a governance signal normalization and scoring engine, replacing older scoring-only language.