### PR TITLE
Add explanation of why redaction alone isn't enough

### DIFF
--- a/index.html
+++ b/index.html
@@ -1126,6 +1126,30 @@
             </div>
         </section>
 
+        <section id="why-redaction" class="container section" style="background:var(--panel);border-radius:18px;padding:56px 42px;border:1px solid rgba(20,40,72,.08)">
+            <div class="eyebrow">Context</div>
+            <h2>Why <span class="hl">Redaction Alone</span> Isn’t Enough</h2>
+            <p class="lead">Cerbi complements your existing logging providers instead of replacing them. You still route data to your sinks using your preferred pipeline, but Cerbi governs what gets emitted so downstream platforms receive compliant, dependable signals.</p>
+            <div class="grid">
+                <article class="col-6 card">
+                    <h3>Field-level control</h3>
+                    <p>Define Required, Disallowed, and Sensitive field rules for every log shape so redaction is only one guardrail among many.</p>
+                </article>
+                <article class="col-6 card">
+                    <h3>Defense in depth</h3>
+                    <p>Compile-time analyzers and runtime validation work together to catch violations early, then block or tag risky events before they leave the service.</p>
+                </article>
+                <article class="col-6 card">
+                    <h3>Operational traceability</h3>
+                    <p>Policy versioning with deployment history shows who changed what and where it is enforced, so redaction decisions stay auditable.</p>
+                </article>
+                <article class="col-6 card">
+                    <h3>Measurable outcomes</h3>
+                    <p>Scoring visibility highlights the quality of each payload and surfaces drift over time, making governance progress transparent.</p>
+                </article>
+            </div>
+        </section>
+
         <section class="container section persona-nav" aria-label="Persona navigation">
             <div class="persona-grid">
                 <a class="persona-card" href="#use-cases">


### PR DESCRIPTION
## Summary
- add a new "Why Redaction Alone Isn’t Enough" section outlining Cerbi’s governance features beyond masking
- highlight field-level rules, analyzers, runtime validation, policy history, scoring visibility, and compatibility with existing logging pipelines

## Testing
- Not run (static site changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f39ba434832dbb145cb1b479db50)

## Summary by Sourcery

Documentation:
- Introduce a contextual "Why Redaction Alone Isn’t Enough" section describing field-level rules, analyzers, runtime validation, policy history, and scoring visibility in Cerbi.