### PR TITLE
Clarify architecture diagram captions and flow

### DIFF
--- a/index-current.html
+++ b/index-current.html
@@ -943,15 +943,14 @@ dotnet add package Cerbi.Governance.Runtime
           <pre class="kbd" style="display:block;padding:14px;white-space:pre-wrap;background:rgba(14,165,255,.06);border:1px solid rgba(14,165,255,.25);border-radius:12px"><code>Application (Serilog / NLog / MEL / CerbiStream)
   │
   ▼
-CerbiShield Plugin / Analyzer (Required / Forbidden Field Enforcement)
+CerbiStream governance (analyzers + runtime validation)
   │
-  ├──▶ Logs go to your standard sinks via OTel / Fluent Bit / Vector / custom pipelines
+  ├──▶ Your log pipeline (OTel / Fluent Bit / Vector / custom) → vendors / sinks (Cerbi is not a router)
   │
-  └──▶ (optional) CerbiStream → Scoring API (governance signal normalization + scoring engine) → CerbiSense (Phase 2)
-              │        │
-              ▼        ▼
-         Governance    ML Analytics
-         Scores        Scoring & Trends</code></pre>
+  └──▶ (optional) Scoring Queue → Scoring API → CerbiShield dashboard
+              │
+              ▼
+        Governance + risk scores</code></pre>
           <button class="btn" data-copy="#architecture code">Copy</button>
         </div>
         <div class="col-6 glass tilt" style="padding:16px">
@@ -959,6 +958,7 @@ CerbiShield Plugin / Analyzer (Required / Forbidden Field Enforcement)
           <div class="img-frame" role="img" aria-label="Architecture diagram">
             <img src="/assets/da3b8164-84d7-400c-a093-154d1eb9fd09.png" alt="CerbiSuite Architecture Diagram" style="width:100%;display:block"/>
           </div>
+          <p class="k" style="margin-top:10px">Canonical path: Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield dashboard. External routing: your log pipeline of choice → vendors/sinks. Cerbi is vendor-agnostic governance + scoring — not log transport.</p>
           <p class="k" style="margin-top:10px">Full architecture (PDF): <a href="/assets/CerbiSuite Architecture.pdf" target="_blank" rel="noopener">Download</a></p>
         </div>
       </div>

--- a/index-draft.html
+++ b/index-draft.html
@@ -1469,11 +1469,11 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Flow</h3>
                     <ul>
-                        <li>Apps & services emit events</li>
+                        <li>Apps & services emit events into CerbiStream (source governance + validation)</li>
                         <li>Build-time analyzers catch schema/PII violations pre-merge</li>
                         <li>Runtime validators redact/flag (relax-mode to roll out safely)</li>
-                        <li>CerbiShield hosts versioned profiles, RBAC, audit history</li>
-                        <li>Downstream sinks receive clean, consistent data</li>
+                        <li>(Optional) governed events enter a Scoring Queue → Scoring API → CerbiShield dashboard for governance + risk scoring</li>
+                        <li>Your log pipeline of choice (OTel, Fluent Bit, Vector, custom) still routes to vendors/sinks; Cerbi stays vendor-agnostic</li>
                     </ul>
                 </article>
                 <figure class="col-6 img-frame arch-diagram card" style="padding:10px">
@@ -1487,7 +1487,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                              loading="lazy" decoding="async">
                     </a>
                     <figcaption class="img-cap">
-                        Source-governed telemetry → durable dashboards, cheaper ingestion, audit-ready evidence.
+                        Canonical path: Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield dashboard.
+                        External routing: your log pipeline of choice → vendors/sinks. Cerbi is vendor-agnostic governance + scoring — not log transport.
                         <a class="arch-pop"
                            href="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png"
                            data-full="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png">Open full size →</a>

--- a/index.html
+++ b/index.html
@@ -1726,11 +1726,11 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Flow</h3>
                     <ul>
-                        <li>Apps & services emit events</li>
+                        <li>Apps & services emit events into CerbiStream (source governance + validation)</li>
                         <li>Build-time analyzers catch schema/PII violations pre-merge</li>
                         <li>Runtime validators redact/flag (relax-mode to roll out safely)</li>
-                        <li>CerbiShield hosts versioned profiles, RBAC, audit history, and deployable policy</li>
-                        <li>Teams route governed events through OTel, Fluent Bit, Vector, or custom pipelines to their sinks; Cerbi never ships your logs to vendors</li>
+                        <li>(Optional) governed events enter a Scoring Queue → Scoring API → CerbiShield dashboard for governance + risk scoring</li>
+                        <li>Your log pipeline of choice (OTel, Fluent Bit, Vector, custom) still routes to vendors/sinks; Cerbi stays vendor-agnostic</li>
                     </ul>
                 </article>
                 <figure class="col-6 img-frame arch-diagram card" style="padding:10px">
@@ -1738,7 +1738,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <img src="assets/architecture/cerbisuite-architecture-1600x900.png" sizes="(max-width: 900px) 100vw, 900px" alt="Cerbi reference architecture diagram" loading="lazy" decoding="async">
                     </a>
                     <figcaption class="img-cap">
-                        Source-governed telemetry → durable dashboards, cheaper ingestion, audit-ready evidence.
+                        Canonical path: Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield dashboard.
+                        External routing: your log pipeline of choice → vendors/sinks. Cerbi is vendor-agnostic governance + scoring — not log transport.
                         <a class="arch-pop" href="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png" data-full="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png">Open full size →</a>
                     </figcaption>
                 </figure>


### PR DESCRIPTION
## Summary
- align architecture flow descriptions with the canonical CerbiStream → Scoring API → CerbiShield path and optional scoring queue
- add explicit vendor-agnostic governance + scoring messaging to architecture captions across pages
- refresh the architecture flow block in the current page to avoid implying Cerbi routes logs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f4545794832d9fff4168bb46e2e0)

## Summary by Sourcery

Clarify and standardize architecture flow descriptions and captions across current, draft, and main site pages to emphasize the canonical CerbiStream → Scoring API → CerbiShield path and vendor-agnostic governance role.

Documentation:
- Update architecture flow bullets and captions to describe the canonical CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield dashboard path.
- Clarify that Cerbi provides governance and scoring while remaining vendor-agnostic and not handling log transport or routing.