### PR TITLE
Align marketing messaging with Cerbi architecture

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     <title>CerbiSuite — Governance-first logging and scoring for .NET</title>
 
     <meta name="theme-color" content="#fffdf7" />
-    <meta name="description" content="Governance-first logging with compile-time and runtime enforcement, redaction posture scoring, schema consistency, and audit-ready visibility—without taking over your log routing." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, runtime logging validation, governance scoring, Scoring API, Cerbi, CerbiSuite" />
+    <meta name="description" content="CerbiStream governs logs at the source while CerbiShield defines and deploys governance policy; the Scoring API measures posture and trends—all without Cerbi routing your data." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, runtime logging validation, governance scoring, Scoring API, Cerbi, CerbiSuite, CerbiStream, CerbiShield" />
     <meta property="og:title" content="CerbiSuite — Governance-first logging and scoring" />
-    <meta property="og:description" content="Validate, redact, and score every payload while your own pipelines keep routing to sinks. Governance you can prove with trends over time." />
+    <meta property="og:description" content="Validate, redact, and score every payload with CerbiStream at the source, CerbiShield managing policy, and the Scoring API grading governance—while your pipelines keep routing to sinks." />
     <meta property="og:image" content="assets/CerbiShield.png" />
 
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Roboto+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -1048,7 +1048,7 @@
                     <h1>
                         Governed logging and scoring that stays out of your routing. <span class="hl">Cerbi validates and scores what your services emit; your pipelines keep sending it to the sinks you choose.</span>
                     </h1>
-                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Enforce schemas in CI and at runtime, document redaction posture, and surface governance trends you can defend. Cerbi doesn’t move your logs—customers keep their pipelines and sinks while Cerbi standardizes payloads, blocks risky fields, and scores outcomes for every service.</p>
+                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Enforce schemas in CI and at runtime, document redaction posture, and surface governance trends you can defend. CerbiStream governs at the source, CerbiShield defines and deploys policy versions, and the Scoring API grades outcomes—your own pipelines keep moving data to the sinks and vendors you choose.</p>
 
                     <!-- Dual CTAs -->
                     <div class="hero-ctas">
@@ -1129,7 +1129,7 @@
         <section id="why-redaction" class="container section" style="background:var(--panel);border-radius:18px;padding:56px 42px;border:1px solid rgba(20,40,72,.08)">
             <div class="eyebrow">Context</div>
             <h2>Why not <span class="hl">“just a redaction library”</span></h2>
-            <p class="lead">Cerbi doesn’t route or store your logs. Customers keep their pipelines and sinks; Cerbi governs what gets emitted, scores the posture, and keeps schema + redaction rules consistent across teams.</p>
+            <p class="lead">Cerbi doesn’t route or store your logs. Customers keep their pipelines and sinks while CerbiStream governs what gets emitted, CerbiShield defines and versions the policies being enforced, and the Scoring API measures posture across teams.</p>
             <div class="grid">
                 <article class="col-6 card">
                     <h3>Field-level control</h3>
@@ -1252,7 +1252,7 @@
         <section id="brief-overview-video" class="container section">
             <div class="eyebrow">Overview</div>
             <h2>Cerbi — <span class="hl">Brief Overview</span></h2>
-            <p class="lead">CerbiStream is a governance-first logging layer for .NET that validates, redacts, and tags every log event before it hits your sinks. Instead of shipping “whatever the app logs” into expensive platforms, Cerbi enforces JSON profiles so only clean, compliant, ML-ready data flows downstream. CerbiShield, the governance dashboard, generates and deploys those profiles across teams so policy lives outside code. Together, they turn logging from an ungoverned cost center into an auditable, measurable part of your architecture.</p>
+            <p class="lead">CerbiStream is a governance-first logging layer for .NET that validates, redacts, and tags every log event before it hits your sinks. Instead of shipping “whatever the app logs” into expensive platforms, Cerbi enforces JSON profiles so only clean, compliant, ML-ready data flows downstream. CerbiShield, the governance dashboard, defines, versions, and deploys those profiles across teams so policy lives outside code, and the Scoring API is the governance scoring engine that tracks posture over time. Together, they turn logging from an ungoverned cost center into an auditable, measurable part of your architecture without ever routing your traffic.</p>
             <div class="card video-card-shell" data-video-card="brief-overview"></div>
         </section>
 
@@ -1564,7 +1564,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <li><strong>Improve standards over time</strong>: scorecards feed back into CerbiShield so teams can tighten policies without breaking pipelines.</li>
             </ol>
 
-            <p class="muted">The Scoring API is the governance signal normalization + scoring engine (it replaces the old “CerbIQ” routing story) and never brokers your traffic.</p>
+            <p class="muted">The Scoring API is the governance signal normalization + scoring engine and it replaces the legacy “CerbIQ-as-router” narrative—Cerbi no longer brokers or forwards traffic.</p>
 
             <p>Cerbi is not a transport layer—it layers governance and scoring on top of your existing choices. Customers keep their current pipelines and routing (Kafka, Event Hubs, Vector, Fluent Bit, HTTP collectors, or anything else) while Cerbi standardizes the payloads and enforcement.</p>
 
@@ -1692,8 +1692,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
 
                     <div class="savings-item">
                         <span class="percent">15%</span>
-                        <strong>Smarter retention &amp; routing</strong>
-                        <p>Noisy streams get shorter hot retention or move to cheaper storage (~15%).</p>
+                        <strong>Smarter retention with your routing</strong>
+                        <p>Noisy streams get shorter hot retention or move to cheaper storage using the pipelines you already own (~15%).</p>
                     </div>
 
                     <div class="savings-item">
@@ -1718,11 +1718,12 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
         <section id="architecture" class="container section">
             <div class="eyebrow">How it fits</div>
             <h2>Reference <span class="hl">Architecture</span></h2>
-            <p class="lead">Cerbi governs telemetry at the source and scores outcomes while your existing pipelines keep routing to sinks and vendors.</p>
+            <p class="lead">CerbiStream governs telemetry at the source, CerbiShield defines and deploys governance policy, and the Scoring API measures posture—your existing pipelines keep routing to sinks and vendors.</p>
             <div class="grid architecture-grid">
                 <article class="col-6 card">
                     <h3>Flow</h3>
                     <ul>
+                        <li>Governance policies are authored, versioned, and deployed from CerbiShield.</li>
                         <li>Apps & services emit events into CerbiStream (source governance + validation)</li>
                         <li>Build-time analyzers catch schema/PII violations pre-merge</li>
                         <li>Runtime validators redact/flag (relax-mode to roll out safely)</li>

--- a/scoring.html
+++ b/scoring.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Governance scoring — Cerbi Scoring API for governed logging</title>
-    <meta name="description" content="Score schema consistency, redaction posture, and governance enforcement across services with the Cerbi Scoring API—while your pipelines keep routing logs to the sinks you choose." />
+    <meta name="description" content="Scoring API is Cerbi's governance scoring engine that grades signals from CerbiStream and CerbiShield while your pipelines keep routing logs to the sinks you choose." />
     <meta name="keywords" content="logging governance, structured logging .NET, governance scoring, redaction posture, compile-time logging enforcement, runtime validation, Cerbi Scoring API" />
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white">
     <header class="text-center py-10 bg-gray-800 shadow-lg">
         <h1 class="text-5xl font-extrabold">Cerbi Scoring API</h1>
-        <p class="text-lg mt-2">Normalize governance signals, score every payload, and keep routing decisions in your own pipelines.</p>
+        <p class="text-lg mt-2">Normalize governance signals from CerbiStream and CerbiShield, score every payload, and keep routing decisions in your own pipelines.</p>
         <a href="index.html" class="mt-4 inline-block px-6 py-3 bg-blue-500 rounded-lg text-white hover:bg-blue-600 transition">Back to Home</a>
     </header>
 
@@ -19,6 +19,7 @@
         <section class="bg-gray-800 rounded-xl p-8 shadow-lg">
             <h2 class="text-3xl font-semibold mb-4">What the Scoring API Represents</h2>
             <p class="text-gray-200">ScoreImpact summarizes how healthy your logging posture is across every service—without Cerbi ever brokering traffic.</p>
+            <p class="text-gray-200 mt-3">CerbiStream governs events at the source, CerbiShield defines and deploys the policies that drive governance signals, and the Scoring API turns those signals into comparable scores while your own routers keep sending logs to the sinks you already use.</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
                 <div class="p-6 bg-gray-700 rounded-lg shadow">
                     <h3 class="text-2xl font-semibold">Coverage</h3>
@@ -55,7 +56,7 @@
                 <li>Uses the same scoring rubric for every team, so policies are enforced evenly without manual checklists.</li>
                 <li>Signals when services diverge from shared baselines, making drift visible without ticket policing.</li>
                 <li>Lets platform teams set defaults once while allowing services to self-correct against the score.</li>
-                <li>Works with any router or collector—Cerbi scores governance data and lets your pipelines keep sending logs to your sinks.</li>
+                <li>Works with any router or collector—CerbiStream and CerbiShield emit governance data, the Scoring API scores it, and your pipelines keep sending logs to your sinks.</li>
             </ul>
         </section>
 
@@ -72,11 +73,11 @@
                 </div>
                 <div>
                     <h3 class="text-xl font-semibold">Does Cerbi route logs?</h3>
-                    <p class="text-gray-200">No. Cerbi observes routing decisions but does not broker or forward log traffic—customers keep their own sinks and pipelines.</p>
+                    <p class="text-gray-200">No. CerbiStream governs events at the source and CerbiShield manages the policies being enforced, but your own routers forward data to sinks—Cerbi never brokers or forwards log traffic.</p>
                 </div>
                 <div>
                     <h3 class="text-xl font-semibold">Do I need a specific router?</h3>
-                    <p class="text-gray-200">No. Scoring works with any router that can emit governance signals and metrics; Cerbi’s Scoring API replaces the old CerbIQ routing story.</p>
+                    <p class="text-gray-200">No. Scoring works with any router that can emit governance signals and metrics; the Scoring API is the scoring engine and the legacy CerbIQ-as-router story is retired.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- refresh marketing copy to stress CerbiStream governance at the source, CerbiShield policy ownership, and Scoring API scoring responsibilities
- clarify that customers keep their own routing pipelines, Cerbi does not transport logs, and CerbIQ-as-router is legacy only
- update scoring page messaging to match current architecture and router-agnostic stance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693304a0ec20832d96bb4425f27fbd3e)

## Summary by Sourcery

Align marketing copy and metadata with the current Cerbi architecture, clearly distinguishing CerbiStream, CerbiShield, and the Scoring API while emphasizing router-agnostic governance.

Enhancements:
- Clarify product responsibilities by explicitly positioning CerbiStream as source governance, CerbiShield as policy definition/deployment, and the Scoring API as the scoring engine across pages.
- Reinforce that Cerbi does not route, broker, or store logs and that customers retain their existing pipelines and routers, updating references to the legacy CerbIQ-as-router narrative.
- Update SEO-related meta descriptions and keywords to reflect the CerbiStream/CerbiShield/Scoring API architecture and router-agnostic stance across the main and scoring pages.