### PR TITLE
Rewrite hero messaging for governance buyers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1046,9 +1046,9 @@
                     </div>
 
                     <h1>
-                        Governed logging and scoring that stays out of your routing. <span class="hl">Cerbi validates and scores what your services emit; your pipelines keep sending it to the sinks you choose.</span>
+                        Govern logs at the source. <span class="hl">Score governance outcomes. Keep your logger, pipeline, and sinks exactly how you want.</span>
                     </h1>
-                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Enforce schemas in CI and at runtime, document redaction posture, and surface governance trends you can defend. CerbiStream governs at the source, CerbiShield defines and deploys policy versions, and the Scoring API grades outcomes—your own pipelines keep moving data to the sinks and vendors you choose.</p>
+                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Cerbi validates every payload where it’s produced, versions policy outside the codebase, and scores governance posture release-to-release. You keep your existing logger and routing while Cerbi enforces schemas, redaction, and auditability at the edge.</p>
 
                     <!-- Dual CTAs -->
                     <div class="hero-ctas">
@@ -1267,15 +1267,15 @@
                     <h3>1. Cut Log Spend</h3>
                     <p class="muted">Normalize fields, roll up noise, and de-duplicate before indexing.</p>
                     <ul>
-                        <li>Score and suppress high-cardinality noise before ingestion costs explode</li>
-                        <li>Separate ingestion from indexing on purpose so indexes stay lean and fast</li>
+                        <li>Govern logs at the source with versioned schemas and redaction before anything leaves the service</li>
+                        <li>Score governance outcomes release-over-release so you can prove controls are working</li>
                     </ul>
                 </article>
                 <article class="col-4 card">
                     <h3>2. Prove Compliance</h3>
                     <p class="muted">Versioned PII policy + redaction metadata you can hand to Risk/Legal.</p>
                     <ul>
-                        <li>Governance profiles catch and redact sensitive fields at build and runtime</li>
+                        <li>Keep your logger and pipeline while policy rides along to any sinks you choose</li>
                         <li>RBAC & audit history in CerbiShield</li>
                     </ul>
                 </article>


### PR DESCRIPTION
## Summary
- update hero headline and subheadline to emphasize source governance, scoring, and pipeline freedom
- adjust initial use-case bullets to speak to governing at the source, scoring outcomes, and keeping existing routing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693306b54090832db09169c0603d5e89)

## Summary by Sourcery

Rewrite hero and use-case marketing messaging to emphasize source-level log governance, outcome scoring, and compatibility with existing logging pipelines.

New Features:
- Update hero headline and subheadline copy to highlight governing logs at the source, scoring governance posture, and preserving existing logger and routing setups.

Enhancements:
- Refine initial use-case bullets to focus on versioned schemas, redaction at the source, release-over-release governance scoring, and policy portability across existing pipelines.