### PR TITLE
Clarify Scoring API positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -1564,7 +1564,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <li><strong>Improve standards over time</strong>: scorecards feed back into CerbiShield so teams can tighten or relax policies confidently while services keep running.</li>
             </ol>
 
-            <p class="muted">The Scoring API is the governance signal normalization + scoring engine and it replaces the legacy “CerbIQ-as-router” narrative—Cerbi does not broker, forward, or replace your log transport.</p>
+            <p class="muted">The Scoring API is the governance signal normalization + scoring engine. The legacy “CerbIQ-as-router/normalization/fan-out” story is retired—CerbIQ was an early idea; the Scoring API is the supported path and Cerbi does not broker, forward, or replace your log transport.</p>
 
             <p>Cerbi is not a log transport layer and does not require pipeline changes. Customers keep their existing routing (Kafka, Event Hubs, Vector, Fluent Bit, HTTP collectors, or anything else) while Cerbi layers governance, validation, and scoring on top.</p>
 

--- a/scoring.html
+++ b/scoring.html
@@ -77,7 +77,7 @@
                 </div>
                 <div>
                     <h3 class="text-xl font-semibold">Do I need a specific router?</h3>
-                    <p class="text-gray-200">No. Scoring works with any router that can emit governance signals and metrics; the Scoring API is the scoring engine and the legacy CerbIQ-as-router story is retired.</p>
+                    <p class="text-gray-200">No. Scoring works with any router that can emit governance signals and metrics; the Scoring API is the scoring engine—Cerbi does not broker or fan-out your log transport.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- update closed-loop governance copy to frame CerbIQ as a retired legacy router concept and point to the Scoring API
- adjust Scoring FAQ to emphasize Scoring API roles without suggesting Cerbi handles routing or fan-out

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330843560c832d81a6dacaad4d93ca)

## Summary by Sourcery

Clarify product messaging around the Scoring API and the legacy CerbIQ router concept in the marketing site copy.

Documentation:
- Update closed-loop governance copy to position CerbIQ as a retired legacy concept and direct users toward the Scoring API as the supported path.
- Adjust Scoring FAQ language to emphasize that the Scoring API is a scoring engine and that Cerbi does not handle routing, brokering, or fan-out of log transport.