### PR TITLE
Refine who it's for blurbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1181,25 +1181,23 @@
                 <article class="card col-4">
                     <h3>Platform / SRE</h3>
                     <p class="muted">
-                        Platform and SRE teams need clean signals without rebuilding pipelines. Cerbi standardizes schemas,
-                        tags governance outcomes, and scores violations before events enter your existing sinks—so dashboards
-                        stay durable and on-call stays calm.
+                        Schema chaos blows up dashboards and on-call. Cerbi standardizes payloads at the source and flags
+                        drift before it ships—result: stable signals and calmer incidents.
                     </p>
                 </article>
                 <article class="card col-4">
                     <h3>Security / Compliance</h3>
                     <p class="muted">
-                        Security and compliance owners need provable redaction posture and governance history. Cerbi enforces
-                        policies in CI and at runtime, and Scoring API trends show how exposure and coverage change over time
-                        without Cerbi ever routing the logs itself.
+                        Sensitive-data risk and missing audit evidence stall reviews. Cerbi enforces and versions policies in
+                        CI/runtime and records deployment history—result: traceable redaction posture you can hand to
+                        auditors.
                     </p>
                 </article>
                 <article class="card col-4">
                     <h3>Engineering Leads</h3>
                     <p class="muted">
-                        Engineering leads battle schema chaos as teams ship logging changes without guardrails. Cerbi keeps
-                        profiles versioned outside code, fails fast in CI and runtime, and scores adherence so consistency
-                        improves without slowing delivery or changing where logs go.
+                        Cross-team inconsistency slows releases. Cerbi keeps schemas versioned outside code, scores adherence,
+                        and blocks regressions in CI—result: consistent logs and faster approvals.
                     </p>
                 </article>
             </div>


### PR DESCRIPTION
## Summary
- rewrite the Who it’s for blurbs to emphasize real pains for Platform/SRE, Security/Compliance, and Engineering Leads
- highlight schema chaos, sensitive-data risk, cross-team inconsistency, and lack of durable audit evidence with concrete operational outcomes

## Testing
- not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330b3055ec832d8ad7f495062494f5)

## Summary by Sourcery

Documentation:
- Refresh the “Who it’s for” blurbs to focus on schema chaos, sensitive-data risk, cross-team inconsistency, and auditability with clearer operational outcomes for each target audience.