### PR TITLE
Update architecture diagrams and captions

### DIFF
--- a/index-current.html
+++ b/index-current.html
@@ -948,7 +948,7 @@ CerbiStream governance (analyzers + runtime validation)
   │
   ├──▶ Your log pipeline (OTel / Fluent Bit / Vector / custom) → vendors / sinks (Cerbi is not a router)
   │
-  └──▶ (optional) Scoring Queue → Scoring API → CerbiShield dashboard
+  └──▶ (optional) Scoring Queue → Scoring API → CerbiShield Dashboards
               │
               ▼
         Governance + risk scores</code></pre>
@@ -957,9 +957,11 @@ CerbiStream governance (analyzers + runtime validation)
         <div class="col-6 glass tilt" style="padding:16px">
           <div class="glare"></div>
           <div class="img-frame" role="img" aria-label="Architecture diagram">
-            <img src="/assets/da3b8164-84d7-400c-a093-154d1eb9fd09.png" alt="CerbiSuite Architecture Diagram" style="width:100%;display:block"/>
+            <img src="/assets/architecture/Cerbi-Architecture.png" alt="CerbiSuite Architecture Diagram" style="width:100%;display:block"/>
           </div>
-          <p class="k" style="margin-top:10px">Canonical path: Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield dashboard. External routing: your log pipeline of choice → vendors/sinks. Cerbi is vendor-agnostic governance + scoring — not log transport.</p>
+          <p class="k" style="margin-top:10px"><strong>Canonical governance/scoring flow:</strong> Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield Dashboards.</p>
+          <p class="k" style="margin-top:10px">Your pipeline of choice routes logs to any sinks.</p>
+          <p class="k" style="margin-top:10px">Cerbi is vendor-agnostic governance + scoring — not log transport.</p>
           <p class="k" style="margin-top:10px">Full architecture (PDF): <a href="/assets/CerbiSuite Architecture.pdf" target="_blank" rel="noopener">Download</a></p>
         </div>
       </div>

--- a/index-draft.html
+++ b/index-draft.html
@@ -1472,7 +1472,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <li>Apps & services emit events into CerbiStream (source governance + validation)</li>
                         <li>Build-time analyzers catch schema/PII violations pre-merge</li>
                         <li>Runtime validators redact/flag (relax-mode to roll out safely)</li>
-                        <li>(Optional) governed events enter a Scoring Queue → Scoring API → CerbiShield dashboard for governance + risk scoring</li>
+                        <li>(Optional) governed events enter a Scoring Queue → Scoring API → CerbiShield Dashboards for governance + risk scoring</li>
                         <li>Your log pipeline of choice (OTel, Fluent Bit, Vector, custom) still routes to vendors/sinks; Cerbi stays vendor-agnostic</li>
                     </ul>
                 </article>
@@ -1481,14 +1481,15 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                        href="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png"
                        data-full="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png"
                        title="Open full-size architecture">
-                        <img src="assets/architecture/cerbisuite-architecture-1600x900.png"
+                        <img src="assets/architecture/Cerbi-Architecture.png"
                              sizes="(max-width: 900px) 100vw, 900px"
                              alt="Cerbi reference architecture diagram"
                              loading="lazy" decoding="async">
                     </a>
                     <figcaption class="img-cap">
-                        Canonical path: Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield dashboard.
-                        External routing: your log pipeline of choice → vendors/sinks. Cerbi is vendor-agnostic governance + scoring — not log transport.
+                        <strong>Canonical governance/scoring flow:</strong> Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield Dashboards.
+                        <div>Your pipeline of choice routes logs to any sinks.</div>
+                        <div>Cerbi is vendor-agnostic governance + scoring — not log transport.</div>
                         <a class="arch-pop"
                            href="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png"
                            data-full="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png">Open full size →</a>

--- a/index.html
+++ b/index.html
@@ -1729,16 +1729,18 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <li>Apps & services emit events into CerbiStream (source governance + validation)</li>
                         <li>Build-time analyzers catch schema/PII violations pre-merge</li>
                         <li>Runtime validators redact/flag (relax-mode to roll out safely)</li>
-                        <li>(Optional) governed events enter a Scoring Queue → Scoring API → CerbiShield dashboard for governance + risk scoring</li>
+                        <li>(Optional) governed events enter a Scoring Queue → Scoring API → CerbiShield Dashboards for governance + risk scoring</li>
                         <li>Your log pipeline of choice (OTel, Fluent Bit, Vector, custom) still routes to vendors/sinks; Cerbi stays vendor-agnostic and never brokers traffic</li>
                     </ul>
                 </article>
                 <figure class="col-6 img-frame arch-diagram card" style="padding:10px">
                     <a class="arch-pop" href="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png" data-full="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png" title="Open full-size architecture">
-                        <img src="assets/architecture/cerbisuite-architecture-1600x900.png" sizes="(max-width: 900px) 100vw, 900px" alt="Cerbi reference architecture diagram" loading="lazy" decoding="async">
+                        <img src="assets/architecture/Cerbi-Architecture.png" sizes="(max-width: 900px) 100vw, 900px" alt="Cerbi reference architecture diagram" loading="lazy" decoding="async">
                     </a>
                     <figcaption class="img-cap">
-                        Canonical path: Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield dashboard. Routing to sinks stays with your pipeline (OTel/Vector/Fluent Bit/etc.). Cerbi governs, validates, and scores—never transports logs.
+                        <strong>Canonical governance/scoring flow:</strong> Apps → CerbiStream → (optional Scoring Queue) → Scoring API → CerbiShield Dashboards.
+                        <div>Your pipeline of choice routes logs to any sinks.</div>
+                        <div>Cerbi is vendor-agnostic governance + scoring — not log transport.</div>
                         <a class="arch-pop" href="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png" data-full="https://raw.githubusercontent.com/Zeroshi/CerbiSite/main/assets/architecture/Cerbi-Architecture.png">Open full size →</a>
                     </figcaption>
                 </figure>


### PR DESCRIPTION
## Summary
- update architecture sections to reference the current diagram asset
- refresh canonical governance/scoring flow copy and CerbiShield Dashboards naming
- add explicit statements about customer-controlled pipelines and vendor-agnostic governance/scoring

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330d447cd4832d8879b85b2a8762c1)

## Summary by Sourcery

Refresh architecture section visuals and copy to align with the current Cerbi reference diagram and governance/scoring narrative.

Enhancements:
- Update architecture diagram image references in draft and current index pages to use the new canonical asset.
- Clarify architecture captions and flow descriptions to emphasize canonical governance/scoring, CerbiShield Dashboards naming, and vendor-agnostic log routing.