### PR TITLE
Update site meta tags for governance keywords

### DIFF
--- a/Features
+++ b/Features
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Features — logging governance and compile-time logging enforcement</title>
-    <meta name="description" content="Feature highlights for logging governance, structured logging .NET, PII redaction logs, and governance scoring." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, logging policy as code, governance scoring" />
+    <title>Features — logging governance and governance policy as code</title>
+    <meta name="description" content="Feature highlights for logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, and governance scoring." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring" />
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white">

--- a/Features.html
+++ b/Features.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Features — logging governance and compile-time logging enforcement</title>
-    <meta name="description" content="Feature highlights for logging governance, structured logging .NET, PII redaction logs, and governance scoring." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, logging policy as code, governance scoring" />
+    <title>Features — logging governance and governance policy as code</title>
+    <meta name="description" content="Feature highlights for logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, and governance scoring." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring" />
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white">

--- a/about.html
+++ b/about.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>About Cerbi — logging governance and PII redaction logs</title>
-    <meta name="description" content="Cerbi brings logging governance, structured logging .NET, compile-time logging enforcement, PII redaction logs, and logging policy as code." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, logging policy as code, governance scoring" />
+    <title>About Cerbi — logging governance and governance scoring</title>
+    <meta name="description" content="Cerbi brings logging governance, structured logging .NET, compile-time logging enforcement, PII redaction logs, governance policy as code, and governance scoring." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/alpinejs/3.10.5/cdn.min.js" defer></script>
     <script>

--- a/index-current.html
+++ b/index-current.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>CerbiSuite — Logging governance, structured logging .NET</title>
-  <meta name="description" content="Logging governance with compile-time logging enforcement, PII redaction logs, logging policy as code, and governance scoring visibility." />
-  <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, logging policy as code, governance scoring, Cerbi" />
+  <title>CerbiSuite — Logging governance and governance scoring for .NET</title>
+  <meta name="description" content="Logging governance with structured logging .NET, compile-time logging enforcement, PII redaction logs, governance policy as code, and governance scoring visibility." />
+  <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, Cerbi" />
   <meta property="og:title" content="CerbiSuite — Unified Logging, Governance & Observability" />
   <meta property="og:description" content="Structured logging, developer-first observability, and governance—without lock-in." />
   <meta property="og:type" content="website" />

--- a/index-draft.html
+++ b/index-draft.html
@@ -11,11 +11,11 @@
     </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>CerbiSuite — Logging governance and structured logging .NET</title>
+    <title>CerbiSuite — Logging governance and governance scoring for .NET</title>
 
     <meta name="theme-color" content="#fffdf7" />
-    <meta name="description" content="Logging governance with compile-time logging enforcement, PII redaction logs, and logging policy as code plus governance scoring." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, logging policy as code, governance scoring, Cerbi, CerbiSuite" />
+    <meta name="description" content="Logging governance with structured logging .NET, compile-time logging enforcement, PII redaction logs, governance policy as code, and governance scoring." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, Cerbi, CerbiSuite" />
     <meta property="og:title" content="CerbiSuite — Unified Logging, Governance & Observability" />
     <meta property="og:description" content="Bring order to log chaos. Enforce structure, enable audit-ready compliance, and feed ML-ready pipelines—without lock-in." />
     <meta property="og:image" content="assets/CerbiShield.png" />

--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
     </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>CerbiSuite — Governance-first logging and scoring for .NET</title>
+    <title>CerbiSuite — Logging governance and governance scoring for .NET</title>
 
     <meta name="theme-color" content="#fffdf7" />
-    <meta name="description" content="CerbiStream governs logs at the source while CerbiShield defines and deploys governance policy; the Scoring API measures posture and trends—all without Cerbi routing your data." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, runtime logging validation, governance scoring, Scoring API, Cerbi, CerbiSuite, CerbiStream, CerbiShield" />
+    <meta name="description" content="Logging governance with structured logging .NET, compile-time logging enforcement, PII redaction logs, governance policy as code, and governance scoring." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, Scoring API, Cerbi, CerbiSuite, CerbiStream, CerbiShield" />
     <meta property="og:title" content="CerbiSuite — Governance-first logging and scoring" />
     <meta property="og:description" content="Validate, redact, and score every payload with CerbiStream at the source, CerbiShield managing policy, and the Scoring API grading governance—while your pipelines keep routing to sinks." />
     <meta property="og:image" content="assets/CerbiShield.png" />

--- a/scoring.html
+++ b/scoring.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Governance Scoring — Cerbi Scoring API</title>
-    <meta name="description" content="Cerbi Scoring API explains ScoreImpact and how governance scoring reduces uncertainty without brokering your log traffic." />
-    <meta name="keywords" content="logging governance, structured logging .NET, governance scoring, redaction posture, compile-time logging enforcement, runtime validation, Cerbi Scoring API" />
+    <meta name="description" content="Governance scoring with logging governance, structured logging .NET, compile-time logging enforcement, PII redaction logs, and governance policy as code." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, runtime validation, Cerbi Scoring API" />
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white">


### PR DESCRIPTION
## Summary
- updated page titles and descriptions to include governance policy as code, compile-time enforcement, and governance scoring language
- aligned keyword lists across pages with logging governance, structured logging .NET, and PII redaction logs terms

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693311692fcc832da711ac964f98951e)

## Summary by Sourcery

Enhancements:
- Align SEO keyword sets across core pages to consistently highlight structured logging .NET, compile-time enforcement, PII redaction logs, and governance scoring.