### PR TITLE
Clarify buyer outcomes in homepage messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -1094,19 +1094,19 @@
                         <div class="audience-pill">
                             <span class="audience-icon">👔</span>
                             <div class="audience-text">
-                                <strong>For CTOs:</strong> Cut costs, ensure compliance
+                                <strong>For CTOs:</strong> Standardize logs across services without policing every PR.
                             </div>
                         </div>
                         <div class="audience-pill">
                             <span class="audience-icon">👨‍💻</span>
                             <div class="audience-text">
-                                <strong>For Developers:</strong> Ship faster with governance built-in
+                                <strong>For Developers:</strong> Make dashboards durable by stabilizing schemas.
                             </div>
                         </div>
                         <div class="audience-pill">
                             <span class="audience-icon">🛡️</span>
                             <div class="audience-text">
-                                <strong>For CISOs:</strong> Automate compliance, sleep better
+                                <strong>For CISOs:</strong> Prevent sensitive fields from escaping with enforceable rules.
                             </div>
                         </div>
                     </div>
@@ -1158,7 +1158,7 @@
             <div class="persona-grid">
                 <a class="persona-card" href="#use-cases">
                     <div class="persona-title">For CTOs &amp; VP Engineering</div>
-                    <p class="persona-desc">See cost, compliance, and delivery impact from governed schemas, redaction posture, and scored trends.</p>
+                    <p class="persona-desc">Score governance outcomes to prove improvement, and see cost and compliance impact from governed schemas and redaction posture.</p>
                     <span class="persona-cta">Jump to outcomes →</span>
                 </a>
                 <a class="persona-card" href="#ecosystem-explore" data-scroll-target="#ecosystem-explore">


### PR DESCRIPTION
## Summary
- Replace vague persona pill copy with concrete logging and governance outcomes
- Update CTO persona description to emphasize scoring governance improvements

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933130b5b60832d946f50811eaa9512)

## Summary by Sourcery

Clarify homepage messaging for key buyer personas to focus on concrete logging and governance outcomes.

Enhancements:
- Refine audience pill copy for CTO, Developer, and CISO personas to highlight specific logging, schema stability, and data protection benefits.
- Update CTO persona card description to emphasize measurable governance outcomes and their impact on cost and compliance.