### PR TITLE
Update roadmap Phase 2 descriptions

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -1913,9 +1913,9 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>Scoring API — governance signal normalization + scoring engine for coverage, violations, redaction posture, and risk</li>
-                        <li>CerbiSense — ML anomaly detection & trend forecasting</li>
-                        <li>Marketplace integrations (Azure/AWS/GCP)</li>
+                        <li>Scoring API GA (governance score ingestion + rollups, no transport)</li>
+                        <li>CerbiSense (optional ML insights on governance metadata)</li>
+                        <li>Optional: “More runtime/IDE governance experiences”</li>
                     </ul>
                 </article>
             </div>

--- a/index.html
+++ b/index.html
@@ -3112,9 +3112,9 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>Scoring API — governance signal normalization + scoring engine for coverage, violations, redaction posture, and risk</li>
-                        <li>CerbiSense — ML anomaly detection & trend forecasting</li>
-                        <li>Marketplace integrations (Azure/AWS/GCP)</li>
+                        <li>Scoring API GA (governance score ingestion + rollups, no transport)</li>
+                        <li>CerbiSense (optional ML insights on governance metadata)</li>
+                        <li>Optional: “More runtime/IDE governance experiences”</li>
                     </ul>
                 </article>
             </div>


### PR DESCRIPTION
## Summary
- refresh Phase 2 roadmap bullets to reflect Scoring API GA scope and optional experiences
- clarify CerbiSense as optional ML insights and avoid implying Cerbi provides routing

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693313aa77cc832d84eec28d875b20ec)

## Summary by Sourcery

Documentation:
- Refresh Phase 2 roadmap bullets to describe Scoring API GA as score ingestion and rollups only, clarify CerbiSense as optional ML governance insights, and replace marketplace integrations with optional runtime/IDE governance experiences.