### PR TITLE
Refine hero CTAs for pilot-focused outreach

### DIFF
--- a/index.html
+++ b/index.html
@@ -1056,11 +1056,17 @@
                             ⚡ Try CerbiStream in 60 Seconds
                         </a>
                         <a href="#contact" class="btn btn-secondary btn-large">
-                            📅 Request Enterprise Demo
+                            🚀 Request Pilot Access
+                        </a>
+                        <a href="#contact" class="btn btn-secondary btn-large">
+                            📊 Book a Governance POC
+                        </a>
+                        <a href="#contact" class="btn btn-secondary btn-large">
+                            🛠️ Early Access for Platform Teams
                         </a>
                     </div>
                     <p class="hero-trust" style="text-align:center;color:var(--muted);font-size:14px;margin-top:16px">
-                        Free for open source. Enterprise licenses available.
+                        Founder-led pilots with hands-on implementation support, governance scorecards, and weekly working sessions for platform teams.
                     </p>
 
                     <div class="hero-stats-row">


### PR DESCRIPTION
## Summary
- replace enterprise demo CTA with pilot-centric options for early platform teams
- update hero support messaging to emphasize founder-led, hands-on pilots

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933145f00d4832da9d69ab10ab07aa1)

## Summary by Sourcery

Refine hero call-to-action buttons and support messaging to target pilot-focused platform teams.

New Features:
- Introduce separate hero CTAs for requesting pilot access, booking a governance POC, and early access for platform teams.

Enhancements:
- Update hero support tagline to emphasize founder-led, hands-on pilots with implementation support and governance scorecards.