### PR TITLE
Add CerbiShield licensing note

### DIFF
--- a/index-current.html
+++ b/index-current.html
@@ -885,6 +885,14 @@ dotnet add package Cerbi.Governance.Runtime
         <li><strong>RBAC:</strong> Enterprise-grade claims-based roles, JWT middleware</li>
         <li><strong>Deploy:</strong> History, rollbacks, multi-target (Enterprise)</li>
       </ul>
+      <div class="note" style="margin:12px 0 10px">
+        <strong>How licensing works</strong>
+        <ul style="margin:6px 0 0 18px">
+          <li>Licenses are based on governed applications.</li>
+          <li>Environments (dev/test/uat/stage/prod) do not multiply app count.</li>
+          <li>The customer pays for their own Azure resources; Cerbi is sized to handle the load.</li>
+        </ul>
+      </div>
       <p class="k">Preview: <a href="https://v0-cerbi-shield-governance-dashboard.vercel.app/" target="_blank" rel="noopener">CerbiShield Dashboard</a></p>
     </article>
 


### PR DESCRIPTION
## Summary
- add a short licensing explainer to the CerbiShield section
- clarify app-based licensing, environment handling, and customer-resourced Azure usage

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693314d1e4c0832d889ba2fe05f0e022)

## Summary by Sourcery

Documentation:
- Add a licensing note to the CerbiShield section explaining app-based licensing, non-multiplicative environments, and customer-funded Azure infrastructure.