### PR TITLE
Add consistent pilot disclaimers to outcome sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@
                                 </article>
                             </div>
                             <p class="muted" style="text-align:center;margin:14px auto 0;max-width:780px;font-size:13px">
-                                Results are based on internal benchmarks and pilot rollouts; actual results will vary.
+                                Figures are illustrative pilot outcomes from governed schemas, redaction posture, and audit evidence; your pipeline and controls will change results.
                             </p>
                         </div>
                     </div>
@@ -1269,6 +1269,7 @@
             <div class="eyebrow">Real outcomes</div>
             <h2><span class="hl">Use Cases</span> (for teams & execs)</h2>
             <p class="lead">Short, concrete wins you can expect. Each can start small and expand safely across the org.</p>
+            <p class="muted" style="max-width:800px">Outcome examples are illustrative pilots grounded in governance controls, redaction posture, schema stability, and audit evidence; expect variance by stack.</p>
 
             <div class="grid">
                 <article class="col-4 card">
@@ -1652,7 +1653,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
         <section id="impact" class="impact-section">
             <h2>Cost &amp; time impact in real teams</h2>
             <p class="impact-note">
-                These are example outcomes from governance-heavy rollouts, not promises. Your stack and rules will change the numbers.
+                Illustrative pilot outcomes from governance-heavy rollouts—schema stability, redaction posture, and audit evidence drive the deltas. Your stack and rules will change the numbers.
             </p>
 
             <div class="impact-grid">
@@ -1719,7 +1720,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             </div>
 
             <p class="impact-disclaimer">
-                All figures are illustrative pilots, not guarantees. Cerbi gives you the controls; results depend on your services, volumes, and how hard you turn the governance dials.
+                All figures are illustrative pilots, not guarantees. Cerbi gives you the controls; results depend on your services, volumes, and how rigorously you govern schemas, redaction posture, and audit evidence.
             </p>
         </section>
 


### PR DESCRIPTION
## Summary
- align hero metrics note with an illustrative pilot disclaimer that highlights governance, redaction posture, and audit evidence
- add an illustrative pilot note to the real outcomes section to set expectations for variance
- tighten impact-section disclaimers to stress schema stability, redaction posture, and audit evidence

## Testing
- not run (HTML content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693315a80af0832d91ac9ea678fb4520)

## Summary by Sourcery

Align and expand outcome-related disclaimers across the page to consistently frame metrics as illustrative pilot results influenced by governance and controls.

Enhancements:
- Clarify hero metrics disclaimer to emphasize illustrative pilot nature and dependence on governed schemas, redaction posture, and audit evidence.
- Add a muted note to the real outcomes section to set expectations that examples are illustrative and may vary by stack and controls.
- Tighten impact-section disclaimers to consistently highlight schema stability, redaction posture, and audit evidence as key drivers of results.