### PR TITLE
Align messaging with routing-first scoring narrative

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Cerbi — logging governance and governance scoring</title>
-    <meta name="description" content="Cerbi brings logging governance, structured logging .NET, compile-time logging enforcement, PII redaction logs, governance policy as code, and governance scoring." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring" />
+    <meta name="description" content="Learn how CerbiStream, CerbiShield, and the Scoring API govern .NET logs without routing your traffic—covering schema consistency, redaction posture, and audit-ready scoring." />
+    <meta name="keywords" content="logging governance, structured logging .NET, governance scoring, Scoring API, redaction posture, vendor agnostic logging" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/alpinejs/3.10.5/cdn.min.js" defer></script>
     <script>
@@ -31,61 +31,61 @@
 </head>
 <body class="bg-gray-900 text-white">
     <header class="text-center py-10 bg-gray-800 shadow-lg">
-        <h1 class="text-5xl font-extrabold">Cerbi Features</h1>
-        <p class="text-lg mt-2">Explore the power of AI-driven logging and observability</p>
+        <h1 class="text-5xl font-extrabold">Cerbi in Plain Language</h1>
+        <p class="text-lg mt-2">Governed logging, redaction, and scoring without replacing your routers or sinks.</p>
         <a href="index.html" class="mt-4 inline-block px-6 py-3 bg-blue-500 rounded-lg text-white hover:bg-blue-600 transition">Back to Home</a>
     </header>
     
     <section class="container mx-auto px-6 py-10">
-        <h2 class="text-4xl font-semibold text-center">Key Features</h2>
+        <h2 class="text-4xl font-semibold text-center">Key Capabilities</h2>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6 text-center">
             <div class="p-6 bg-gray-700 rounded-lg shadow-lg feature-card">
-                <h3 class="text-2xl font-bold">AI-Powered Insights</h3>
-                <p class="mt-2">Analyze logs with real-time machine learning models.</p>
+                <h3 class="text-2xl font-bold">Govern at the Source</h3>
+                <p class="mt-2">CerbiStream enforces schemas and redaction rules inside your services before data reaches any sink.</p>
             </div>
             <div class="p-6 bg-gray-700 rounded-lg shadow-lg feature-card">
-                <h3 class="text-2xl font-bold">Multi-Cloud Ready</h3>
-                <p class="mt-2">Seamlessly integrates with AWS, Azure, and GCP.</p>
+                <h3 class="text-2xl font-bold">Keep Your Pipelines</h3>
+                <p class="mt-2">You keep OpenTelemetry, Fluent Bit, Vector, or custom routers—Cerbi never brokers or fans out your logs.</p>
             </div>
             <div class="p-6 bg-gray-700 rounded-lg shadow-lg feature-card">
-                <h3 class="text-2xl font-bold">Secure & Encrypted</h3>
-                <p class="mt-2">End-to-end encryption ensures log security.</p>
+                <h3 class="text-2xl font-bold">Score Governance</h3>
+                <p class="mt-2">The Scoring API normalizes governance signals and grades coverage, violations, and posture per governed app.</p>
             </div>
         </div>
     </section>
     
     <section class="container mx-auto px-6 py-10 text-center">
-        <h2 class="text-4xl font-semibold">Real-Time Stats</h2>
+        <h2 class="text-4xl font-semibold">How Cerbi Fits</h2>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6">
             <div class="p-6 bg-gray-700 rounded-lg shadow-lg">
-                <h3 class="text-3xl font-bold" id="logsProcessed">500,000</h3>
-                <p>Logs Processed</p>
+                <h3 class="text-3xl font-bold">CerbiStream</h3>
+                <p>Runtime validators and analyzers keep schemas and sensitive fields governed inside your codebase.</p>
             </div>
             <div class="p-6 bg-gray-700 rounded-lg shadow-lg">
-                <h3 class="text-3xl font-bold">99.99%</h3>
-                <p>Uptime Guarantee</p>
+                <h3 class="text-3xl font-bold">CerbiShield</h3>
+                <p>Profiles, RBAC, and history live in your tenant—policy stays outside app code but inside your control.</p>
             </div>
             <div class="p-6 bg-gray-700 rounded-lg shadow-lg">
-                <h3 class="text-3xl font-bold">50+</h3>
-                <p>Enterprise Clients</p>
+                <h3 class="text-3xl font-bold">Scoring API</h3>
+                <p>Aggregates governance signals without touching payload routing so teams can prove posture per governed application.</p>
             </div>
         </div>
     </section>
-    
+
     <section class="container mx-auto px-6 py-10">
-        <h2 class="text-4xl font-semibold text-center">Expandable Features</h2>
+        <h2 class="text-4xl font-semibold text-center">What Customers Ask</h2>
         <div class="mt-6 space-y-4 max-w-3xl mx-auto">
             <div class="bg-gray-700 p-4 rounded-lg shadow-lg" x-data="{ open: false }">
-                <button @click="open = !open" class="w-full text-left text-xl font-semibold">🚀 High Performance</button>
-                <p x-show="open" class="mt-2">Cerbi processes millions of logs in real-time with minimal latency.</p>
+                <button @click="open = !open" class="w-full text-left text-xl font-semibold">🚀 Does Cerbi route my logs?</button>
+                <p x-show="open" class="mt-2">No. Your pipelines and routers keep sending payloads to your sinks. Cerbi governs and scores without brokering traffic.</p>
             </div>
             <div class="bg-gray-700 p-4 rounded-lg shadow-lg" x-data="{ open: false }">
-                <button @click="open = !open" class="w-full text-left text-xl font-semibold">🔍 Deep Observability</button>
-                <p x-show="open" class="mt-2">Leverage AI to uncover hidden patterns and trends in your logs.</p>
+                <button @click="open = !open" class="w-full text-left text-xl font-semibold">🔍 How is it priced?</button>
+                <p x-show="open" class="mt-2">Licensing is per governed application. No per-environment multipliers or traffic tax.</p>
             </div>
             <div class="bg-gray-700 p-4 rounded-lg shadow-lg" x-data="{ open: false }">
-                <button @click="open = !open" class="w-full text-left text-xl font-semibold">⚙️ Developer Friendly</button>
-                <p x-show="open" class="mt-2">Easily integrate with your application using a simple API.</p>
+                <button @click="open = !open" class="w-full text-left text-xl font-semibold">⚙️ What changes in my stack?</button>
+                <p x-show="open" class="mt-2">Add CerbiStream and the governance analyzers to your .NET services; keep your existing collectors and observability vendors.</p>
             </div>
         </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     <title>CerbiSuite — Logging governance and governance scoring for .NET</title>
 
     <meta name="theme-color" content="#fffdf7" />
-    <meta name="description" content="Logging governance with structured logging .NET, compile-time logging enforcement, PII redaction logs, governance policy as code, and governance scoring." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, Scoring API, Cerbi, CerbiSuite, CerbiStream, CerbiShield" />
+    <meta name="description" content="Governance-first logging for .NET that validates, redacts, and scores payloads without routing your logs. CerbiStream, CerbiShield, and the Scoring API keep your pipelines and sinks unchanged." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, Scoring API, Cerbi, CerbiSuite, CerbiStream, CerbiShield, vendor agnostic" />
     <meta property="og:title" content="CerbiSuite — Governance-first logging and scoring" />
-    <meta property="og:description" content="Validate, redact, and score every payload with CerbiStream at the source, CerbiShield managing policy, and the Scoring API grading governance—while your pipelines keep routing to sinks." />
+    <meta property="og:description" content="Validate, redact, and score every payload with CerbiStream at the source, CerbiShield managing policy, and the Scoring API grading governance while your pipelines keep routing to your sinks." />
     <meta property="og:image" content="assets/CerbiShield.png" />
 
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Roboto+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -1046,9 +1046,9 @@
                     </div>
 
                     <h1>
-                        Govern logs at the source. <span class="hl">Score governance outcomes. Keep your logger, pipeline, and sinks exactly how you want.</span>
+                        Govern logs at the source. <span class="hl">Score governance outcomes. Keep your logger, pipelines, and sinks exactly how you want.</span>
                     </h1>
-                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Cerbi validates every payload where it’s produced, versions policy outside the codebase, and scores governance posture release-to-release. You keep your existing logger and routing while Cerbi enforces schemas, redaction, and auditability at the edge.</p>
+                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Cerbi validates every payload where it’s produced, versions policy outside the codebase, and scores governance posture release-to-release. You keep your existing logger and routing—Cerbi never brokers traffic—while Cerbi enforces schemas, redaction, and auditability at the edge via the Scoring API.</p>
 
                     <!-- Dual CTAs -->
                     <div class="hero-ctas">
@@ -1135,7 +1135,7 @@
         <section id="why-redaction" class="container section" style="background:var(--panel);border-radius:18px;padding:56px 42px;border:1px solid rgba(20,40,72,.08)">
             <div class="eyebrow">Context</div>
             <h2>Why <span class="hl">Redaction Alone Isn’t Enough</span></h2>
-            <p class="lead">Cerbi complements Serilog, NLog, and Microsoft.Extensions.Logging by governing payloads before they hit your sinks. Instead of relying on ad-hoc masking, Cerbi combines policy, analyzers, runtime guards, versioning, and scoring so redaction is one layer in a governed pipeline.</p>
+            <p class="lead">Cerbi complements Serilog, NLog, and Microsoft.Extensions.Logging by governing payloads before they hit your sinks. Instead of relying on ad-hoc masking, Cerbi combines policy, analyzers, runtime guards, versioning, and scoring so redaction is one layer in a governed pipeline you keep routing.</p>
             <div class="grid">
                 <article class="col-6 card">
                     <h3>Required/Disallowed/Sensitive policy</h3>
@@ -1164,12 +1164,12 @@
             <div class="persona-grid">
                 <a class="persona-card" href="#use-cases">
                     <div class="persona-title">For CTOs &amp; VP Engineering</div>
-                    <p class="persona-desc">Score governance outcomes to prove improvement, and see cost and compliance impact from governed schemas and redaction posture.</p>
+                    <p class="persona-desc">Score governance outcomes to prove improvement, and see cost and compliance impact from governed schemas and redaction posture without swapping log vendors.</p>
                     <span class="persona-cta">Jump to outcomes →</span>
                 </a>
                 <a class="persona-card" href="#ecosystem-explore" data-scroll-target="#ecosystem-explore">
                     <div class="persona-title">For Developers &amp; Platform Teams</div>
-                    <p class="persona-desc">Skip to the Quick Start, NuGet install, and see how Cerbi governs payloads without owning your routing.</p>
+                    <p class="persona-desc">Skip to the Quick Start, NuGet install, and see how Cerbi governs payloads while you keep your agents, collectors, and sinks.</p>
                     <span class="persona-cta">Explore the stack →</span>
                 </a>
                 <a class="persona-card" href="#compliance">
@@ -1479,7 +1479,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
         <section id="governance" class="container section">
             <div class="eyebrow">How governance works</div>
             <h2 id="scoring-flow">Governance Scoring <span class="hl">Flow</span></h2>
-            <p class="lead">From runtime validation to dashboard visualization—track the journey of every governance score.</p>
+            <p class="lead">From runtime validation to dashboard visualization—governance signals flow to the Scoring API while your log routers keep sending payloads to the sinks you already trust.</p>
 
             <div class="card" style="padding:18px; overflow:visible; position:relative">
                 <div class="flow-nodes" role="list" aria-label="Governance flow steps">
@@ -1489,7 +1489,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <div class="flow-title">Runtime Validation</div>
                         <div class="flow-details">
                             <h4>Plugin Validates Event</h4>
-                            <p>Governance plugin checks log against profile rules and computes impact score.</p>
+                            <p>Governance plugin checks each log against profile rules, computes the impact score, and tags the event before your router ships it.</p>
                             <ul>
                                 <li>Severity-weighted scoring</li>
                                 <li>Plugin contributions</li>
@@ -1504,7 +1504,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <div class="flow-title">Async Ship</div>
                         <div class="flow-details">
                             <h4>Background Transmission</h4>
-                            <p>Score data ships to the Scoring API for ingest/normalize/compute ScoreImpact—non-blocking and batched.</p>
+                            <p>Governance signals ship asynchronously to the Scoring API for ingest/normalize/compute ScoreImpact—non-blocking and batched, and separate from your payload routing.</p>
                             <ul>
                                 <li>Non-blocking</li>
                                 <li>Batched</li>
@@ -1736,8 +1736,8 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <li>Apps & services emit events into CerbiStream (source governance + validation)</li>
                         <li>Build-time analyzers catch schema/PII violations pre-merge</li>
                         <li>Runtime validators redact/flag (relax-mode to roll out safely)</li>
-                        <li>(Optional) governed events enter a Scoring Queue → Scoring API → CerbiShield Dashboards for governance + risk scoring</li>
-                        <li>Your log pipeline of choice (OTel, Fluent Bit, Vector, custom) still routes to vendors/sinks; Cerbi stays vendor-agnostic and never brokers traffic</li>
+                        <li>(Optional) governed signals enter a Scoring Queue → Scoring API → CerbiShield Dashboards for governance + risk scoring</li>
+                        <li>Your log pipeline of choice (OTel, Fluent Bit, Vector, custom) still routes payloads to vendors/sinks; Cerbi stays vendor-agnostic and never brokers traffic</li>
                     </ul>
                 </article>
                 <figure class="col-6 img-frame arch-diagram card" style="padding:10px">
@@ -3110,18 +3110,19 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 1 (Current)</h3>
                     <ul>
-                        <li>CerbiStream GA (.NET structured logger)</li>
+                        <li>CerbiStream GA (.NET structured logger + governance tagging)</li>
                         <li>Governance analyzers (Roslyn)</li>
                         <li>Runtime validators (redaction, relax-mode)</li>
                         <li>CerbiShield Beta — profiles, RBAC, audit history</li>
+                        <li>Scoring API Preview — governance scoring without owning your routing</li>
                     </ul>
                 </article>
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>Scoring API GA (governance score ingestion + rollups, no transport)</li>
+                        <li>Scoring API GA (normalized score ingestion + rollups, no transport)</li>
                         <li>CerbiSense (optional ML insights on governance metadata)</li>
-                        <li>Optional: “More runtime/IDE governance experiences”</li>
+                        <li>More runtime/IDE governance experiences</li>
                     </ul>
                 </article>
             </div>
@@ -3423,11 +3424,11 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         <div class="faq-answer">
                             <p>
                                 CerbiStream core and the shared governance libraries (for example, Cerbi.Governance.Core and
-                                Cerbi.Governance.Runtime) are open source under the MIT license. You can use them in both open
-                                source and commercial projects. CerbiShield (the governance dashboard, APIs, and reporting) is
-                                licensed commercially for enterprise customers, with subscriptions that include support, SLAs,
-                                and advanced features. Check each repo or NuGet page for the exact license, but the general
-                                rule is: logging/runtime pieces are permissive, governance/dashboard/reporting are paid.
+                                Cerbi.Governance.Runtime) are open source under the MIT license. CerbiShield (the governance
+                                dashboard, APIs, reporting, and scoring) is licensed commercially <strong>per governed
+                                application</strong>—not per environment—and includes support and SLAs. Check each repo or
+                                NuGet page for the exact license; runtime pieces are permissive, governance/dashboard/scoring
+                                are paid.
                             </p>
                         </div>
                     </div>

--- a/scoring.html
+++ b/scoring.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Governance Scoring — Cerbi Scoring API</title>
-    <meta name="description" content="Governance scoring with logging governance, structured logging .NET, compile-time logging enforcement, PII redaction logs, and governance policy as code." />
-    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, runtime validation, Cerbi Scoring API" />
+    <meta name="description" content="Cerbi's Scoring API normalizes governance signals from CerbiStream and CerbiShield without routing your logs. Score coverage, redaction posture, and violations while your pipelines keep sending data to your sinks." />
+    <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, runtime validation, Cerbi Scoring API, log routing agnostic" />
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white">


### PR DESCRIPTION
## Summary
- update hero, personas, and architecture messaging to emphasize routing-agnostic governance and the Scoring API
- refresh roadmap, redaction, and licensing copy to match current Cerbi posture and per-app licensing
- align supporting pages (scoring, about) and SEO metadata with the routing-safe scoring narrative

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933178af0fc832d8e076a27ad3aeb0d)

## Summary by Sourcery

Align Cerbi marketing site content with a routing-agnostic, Scoring API–centric governance narrative across the homepage, about page, and scoring page.

Documentation:
- Update hero, personas, and product descriptions to emphasize governance at the source while keeping existing log routers, pipelines, and sinks unchanged.
- Clarify the roles of CerbiStream, CerbiShield, and the Scoring API, including routing-agnostic scoring behavior and governance signal flow.
- Refresh roadmap and FAQ licensing copy to highlight the Scoring API phases and per-governed-application commercial licensing model.
- Revise SEO metadata on core pages to reflect routing-safe governance and scoring, including updated descriptions and keywords.