### PR TITLE
Clarify routing architecture and Scoring API role

### DIFF
--- a/index.html
+++ b/index.html
@@ -1573,9 +1573,9 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <li><strong>Improve standards over time</strong>: scorecards feed back into CerbiShield so teams can tighten or relax policies confidently while services keep running.</li>
             </ol>
 
-            <p class="muted">The Scoring API is the governance signal normalization + scoring engine. The legacy “CerbIQ-as-router/normalization/fan-out” story is retired—CerbIQ was an early idea; the Scoring API is the supported path and Cerbi does not broker, forward, or replace your log transport.</p>
+            <p class="muted">The Scoring API is the governance signal normalization + scoring engine. The legacy “CerbIQ-as-router/normalization/fan-out” story is fully retired—CerbIQ is deprecated. Cerbi never brokers, forwards, or replaces your transport to Splunk, Datadog, ELK, OpenSearch, or any other sink.</p>
 
-            <p>Cerbi is not a log transport layer and does not require pipeline changes. Customers keep their existing routing (Kafka, Event Hubs, Vector, Fluent Bit, HTTP collectors, or anything else) while Cerbi layers governance, validation, and scoring on top.</p>
+            <p>Cerbi is not a log transport layer and does not require pipeline changes. Customers keep their existing routing (Kafka, Event Hubs, Vector, Fluent Bit, HTTP collectors, or anything else) while Cerbi layers governance, validation, and scoring metadata on top—your pipelines continue delivering payloads to vendors unchanged.</p>
 
             <div class="card" style="padding:14px 18px; margin-top:12px;">
                 <h3 style="margin-top:0">Why this matters for Platform &amp; SRE</h3>

--- a/scoring.html
+++ b/scoring.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Governance Scoring — Cerbi Scoring API</title>
-    <meta name="description" content="Cerbi's Scoring API normalizes governance signals from CerbiStream and CerbiShield without routing your logs. Score coverage, redaction posture, and violations while your pipelines keep sending data to your sinks." />
+    <meta name="description" content="Cerbi's Scoring API normalizes governance signals from CerbiStream and CerbiShield without routing your logs. Score coverage, redaction posture, and violations while your existing pipelines keep sending data to Splunk, Datadog, ELK, OpenSearch, or any other sink." />
     <meta name="keywords" content="logging governance, structured logging .NET, PII redaction logs, compile-time logging enforcement, governance policy as code, governance scoring, runtime validation, Cerbi Scoring API, log routing agnostic" />
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white">
     <header class="text-center py-10 bg-gray-800 shadow-lg">
         <h1 class="text-5xl font-extrabold">Governance Scoring</h1>
-        <p class="text-lg mt-2">ScoreImpact turns CerbiStream and CerbiShield signals into a single score while your routers keep sending logs wherever you choose.</p>
+        <p class="text-lg mt-2">ScoreImpact turns CerbiStream and CerbiShield signals into a single score while your existing routers and collectors keep sending logs wherever you choose.</p>
         <a href="index.html" class="mt-4 inline-block px-6 py-3 bg-blue-500 rounded-lg text-white hover:bg-blue-600 transition">Back to Home</a>
     </header>
 


### PR DESCRIPTION
## Summary
- update site copy to clarify Scoring API owns governance signal scoring while CerbiIQ routing is deprecated
- reinforce that customers’ existing pipelines route to Splunk/Datadog/ELK/OpenSearch and Cerbi does not broker traffic

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331a17608c832d95d690e4077af7d2)

## Summary by Sourcery

Clarify product messaging around the Scoring API’s role in governance scoring and Cerbi’s non-involvement in log transport or routing.

Documentation:
- Update marketing copy to state that CerbIQ routing is deprecated and the Scoring API is the supported path for governance scoring.
- Clarify that Cerbi does not broker or replace log transport and that existing pipelines continue sending data directly to observability sinks like Splunk, Datadog, ELK, and OpenSearch.