### PR TITLE
Update Phase 2 roadmap messaging

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -1913,12 +1913,13 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>Scoring API GA (governance score ingestion + rollups, no transport)</li>
-                        <li>CerbiSense (optional ML insights on governance metadata)</li>
+                        <li>Scoring API — governance signal ingestion, normalization of scoring events, and rollups for dashboards</li>
+                        <li>CerbiSense — optional ML analytics on metadata</li>
                         <li>Optional: “More runtime/IDE governance experiences”</li>
                     </ul>
                 </article>
             </div>
+            <p class="note">Routing to external log vendors is outside Cerbi; your pipeline remains in control.</p>
         </section>
 
         <!-- CerbiSuite story video BEFORE Contact/Get in Touch -->

--- a/index.html
+++ b/index.html
@@ -3120,12 +3120,13 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                 <article class="col-6 card">
                     <h3>Phase 2 (Planned)</h3>
                     <ul>
-                        <li>Scoring API GA (normalized score ingestion + rollups, no transport)</li>
-                        <li>CerbiSense (optional ML insights on governance metadata)</li>
+                        <li>Scoring API — governance signal ingestion, normalization of scoring events, and rollups for dashboards</li>
+                        <li>CerbiSense — optional ML analytics on metadata</li>
                         <li>More runtime/IDE governance experiences</li>
                     </ul>
                 </article>
             </div>
+            <p class="note">Routing to external log vendors is outside Cerbi; your pipeline remains in control.</p>
         </section>
 
         <!-- Video Library Gallery -->


### PR DESCRIPTION
## Summary
- refresh Phase 2 roadmap bullets to detail Scoring API responsibilities and CerbiSense analytics scope
- add note clarifying routing to external log vendors remains outside Cerbi

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331b2a96bc832d904f92a8f21000d9)

## Summary by Sourcery

Update Phase 2 roadmap messaging on the marketing pages to clarify product responsibilities and scope.

Documentation:
- Clarify Scoring API responsibilities around governance signal ingestion, event normalization, and dashboard rollups in the Phase 2 roadmap copy.
- Simplify CerbiSense description to emphasize optional ML analytics on metadata.
- Add a note that routing to external log vendors remains outside Cerbi and under the user’s pipeline control.