### PR TITLE
Add interoperability callout on Cerbi scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -1811,6 +1811,16 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                     </ul>
                 </article>
             </div>
+            <div class="card" style="margin-top:18px;background:var(--panel-2);border:1px dashed rgba(20,40,72,.2);color:var(--text)">
+                <h3 style="margin-top:4px">What Cerbi does <em>not</em> do</h3>
+                <p class="muted" style="margin:0 0 10px">Friendly reminder from the engineering team:</p>
+                <ul style="margin:0;padding-left:18px;display:grid;gap:6px">
+                    <li>We don’t replace your logging vendors or observability stacks.</li>
+                    <li>We don’t make you change sinks or collectors you already trust.</li>
+                    <li>We don’t broker or route logs—your pipelines keep doing that.</li>
+                </ul>
+                <p style="margin:12px 0 4px">Cerbi enforces governance at the source and attaches scoring signals so the tools you already use receive cleaner, consistent data.</p>
+            </div>
         </section>
 
         <section id="packages" class="container section">


### PR DESCRIPTION
## Summary
- add a friendly callout near the interoperability section clarifying what Cerbi does not do
- highlight that Cerbi enforces governance and scoring without replacing sinks or routing logs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331c83d40c832db1e1e8ea1dfd9099)

## Summary by Sourcery

Documentation:
- Document that Cerbi does not replace existing logging vendors, observability stacks, or log routing pipelines, and instead focuses on source governance and scoring.