### PR TITLE
Emphasize tenant-hosted CerbiShield governance features

### DIFF
--- a/index.html
+++ b/index.html
@@ -1260,7 +1260,7 @@
         <section id="brief-overview-video" class="container section">
             <div class="eyebrow">Overview</div>
             <h2>Cerbi — <span class="hl">Brief Overview</span></h2>
-            <p class="lead">CerbiStream is a governance-first logging layer for .NET that validates, redacts, and tags every log event before it hits your sinks. Instead of shipping “whatever the app logs” into expensive platforms, Cerbi enforces JSON profiles so only clean, compliant, ML-ready data flows downstream. CerbiShield, the governance dashboard, defines, versions, and deploys those profiles across teams so policy lives outside code, and the Scoring API is the governance scoring engine that tracks posture over time. Together, they turn logging from an ungoverned cost center into an auditable, measurable part of your architecture without ever routing your traffic.</p>
+            <p class="lead">CerbiStream is a governance-first logging layer for .NET that validates, redacts, and tags every log event before it hits your sinks. Instead of shipping “whatever the app logs” into expensive platforms, Cerbi enforces JSON profiles so only clean, compliant, ML-ready data flows downstream. CerbiShield is the tenant-hosted governance brain and scorecard layer that defines, versions, and deploys those profiles with RBAC and audit history—customers own the infrastructure and data plane while policy stays outside code. The Scoring API is the governance scoring engine that tracks posture over time. Together, they turn logging from an ungoverned cost center into an auditable, measurable part of your architecture without ever routing your traffic.</p>
             <div class="card video-card-shell" data-video-card="brief-overview"></div>
         </section>
 


### PR DESCRIPTION
## Summary
- expand CerbiShield overview to underline tenant-hosted deployment and customer-owned data plane
- highlight RBAC, audit history, and versioned governance profiles as part of the governance brain and scorecards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331e388198832daadfc5c73f2878d2)

## Summary by Sourcery

Documentation:
- Update product overview text to highlight tenant-hosted CerbiShield, customer-owned infrastructure/data plane, and governance features such as RBAC and audit history.