### PR TITLE
Refresh messaging for hero and solutions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1046,9 +1046,9 @@
                     </div>
 
                     <h1>
-                        Govern logs at the source. <span class="hl">Score governance outcomes. Keep your logger, pipelines, and sinks exactly how you want.</span>
+                        Reduce observability chaos at the edge. <span class="hl">Govern noisy, unstructured logs before they hit your sinks and stop schema drift with CI + runtime guardrails.</span>
                     </h1>
-                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Cerbi validates every payload where it’s produced, versions policy outside the codebase, and scores governance posture release-to-release. You keep your existing logger and routing—Cerbi never brokers traffic—while Cerbi enforces schemas, redaction, and auditability at the edge via the Scoring API.</p>
+                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Cerbi helps SRE, DevOps, and .NET teams reduce noise before ingestion, make redaction automatic, and prevent misconfiguration-led ingestion surprises. We validate every payload where it’s produced, keep policy versioned outside the codebase, and score governance posture release-to-release—without changing your logger or routing.</p>
 
                     <!-- Dual CTAs -->
                     <div class="hero-ctas">
@@ -1590,25 +1590,25 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             <p class="lead">Clear problems, concrete solutions—for executives, security teams, and developers.</p>
 
             <div class="pitch-grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:18px;margin-top:18px">
-                <div class="card">
+                    <div class="card">
                     <h3>The Problem</h3>
-                    <p class="muted">Audit Nightmares: manual log reviews and missing proof of PII redaction.</p>
+                    <p class="muted">Observability cost anxiety driven by noisy, unstructured logs and accidental ingestion.</p>
                     <h3>Our Solution</h3>
-                    <p>Automated compliance: build-time + runtime governance, versioned policies and audit trails.</p>
+                    <p>Reduce noise before ingestion with schema-first governance and routing guardrails that keep traffic intentional.</p>
                 </div>
 
                 <div class="card">
                     <h3>The Problem</h3>
-                    <p class="muted">Runaway Log Costs: high-cardinality fields explode your index size.</p>
+                    <p class="muted">Sensitive data redaction is brittle—manual rules drift and teams lack proof it’s working.</p>
                     <h3>Our Solution</h3>
-                    <p>Pre-index normalization and rollups reduce ingestion and storage costs.</p>
+                    <p>Make redaction automatic with versioned policies, analyzers, and runtime validators that score coverage on every build.</p>
                 </div>
 
                 <div class="card">
                     <h3>The Problem</h3>
-                    <p class="muted">Dashboard Drift: field changes break charts and alerts.</p>
+                    <p class="muted">Misconfigurations lead to schema drift, broken dashboards, and surprise ingestion across sinks.</p>
                     <h3>Our Solution</h3>
-                    <p>Governance profiles enforce stable schemas so dashboards remain durable.</p>
+                    <p>Stop schema drift and turn governance into CI + runtime guardrails so dashboards, alerts, and pipelines stay predictable.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- update hero headline and subcopy to emphasize reducing noise before ingestion, automatic redaction, and governance guardrails
- rewrite problem/solution cards to address observability cost anxiety, noisy logs, redaction friction, and misconfiguration-driven drift

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331e988408832d94047733dfa1b86f)

## Summary by Sourcery

Refresh marketing messaging on the homepage hero and challenge/solution section to emphasize noise reduction before ingestion, automatic redaction, and governance guardrails.

Documentation:
- Update hero headline and subcopy to focus on reducing observability chaos at the edge and preventing misconfiguration-driven ingestion issues.
- Rewrite problem/solution cards to highlight observability cost anxiety, brittle redaction, and schema drift, along with Cerbi’s guardrail-based solutions.