### PR TITLE
Improve styling and spacing for trust/adoption sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,6 +573,14 @@
         .hero h1 { margin: 10px 0 8px; font-size: clamp(26px,4.6vw,44px); line-height: 1.1; background: linear-gradient(90deg, var(--brand), #ff8443 35%, #0f63ff 80%); -webkit-background-clip: text; background-clip: text; color: transparent; min-height: 2.4em; }
         .sub { color: var(--muted); max-width: 70ch; min-height: 2.2em; }
         .section { padding: 28px 0 }
+        .panel-section {
+            background: var(--panel);
+            border-radius: 18px;
+            padding: 48px 42px;
+            border: 1px solid rgba(20,40,72,.08);
+            box-shadow: 0 18px 38px rgba(10,16,30,.06);
+        }
+        .panel-section + .panel-section { margin-top: 32px }
         .eyebrow { font-size: 12px; letter-spacing: .16em; color: var(--muted); text-transform: uppercase }
         .lead { color: var(--muted) }
         .grid { display: grid; gap: 14px; grid-template-columns: repeat(4,minmax(0,1fr)) }
@@ -1754,7 +1762,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             </div>
         </section>
 
-        <section id="trust" class="container section" style="background:var(--panel);border-radius:18px;padding:44px 42px;border:1px solid rgba(20,40,72,.08)">
+        <section id="trust" class="container section panel-section">
             <div class="eyebrow">Trust</div>
             <h2>Control and confidence <span class="hl">by design</span></h2>
             <p class="muted" style="max-width:820px;margin:0 auto 24px">Deployment, governance, and routing stay under your control. Cerbi enforces policy without taking over your log transport or locking you into a vendor path.</p>
@@ -1767,7 +1775,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             </ul>
         </section>
 
-        <section id="adoption-safety" class="container section" style="background:var(--panel);border-radius:18px;padding:48px 42px;border:1px solid rgba(20,40,72,.08)">
+        <section id="adoption-safety" class="container section panel-section">
             <div class="eyebrow">Adoption safety</div>
             <h2>Governance you can roll out <span class="hl">without disruption</span></h2>
             <div class="grid" style="gap:22px">


### PR DESCRIPTION
## Summary
- add a shared `panel-section` style to unify panel padding, border, and shadow
- apply the shared style to the Trust and Adoption safety sections
- add spacing between consecutive panel sections to separate the blocks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933244701ec832d92d6d60c77784cbf)

## Summary by Sourcery

Introduce a shared panel-section style and apply it to the Trust and Adoption safety sections to unify their visual appearance and spacing.

Enhancements:
- Add a reusable panel-section class to standardize panel background, padding, border, and shadow.
- Apply the shared panel-section styling to the Trust and Adoption safety sections and add spacing between consecutive panels.