### PR TITLE
Add spacing before context section

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,6 +573,10 @@
         .hero h1 { margin: 10px 0 8px; font-size: clamp(26px,4.6vw,44px); line-height: 1.1; background: linear-gradient(90deg, var(--brand), #ff8443 35%, #0f63ff 80%); -webkit-background-clip: text; background-clip: text; color: transparent; min-height: 2.4em; }
         .sub { color: var(--muted); max-width: 70ch; min-height: 2.2em; }
         .section { padding: 28px 0 }
+        #why-redaction {
+            margin-top: clamp(28px, 4vw, 46px);
+            scroll-margin-top: calc(var(--nav-h) + 14px);
+        }
         .panel-section {
             background: var(--panel);
             border-radius: 18px;


### PR DESCRIPTION
## Summary
- add vertical spacing to the Context section to prevent it from overlapping the preceding content
- set a scroll margin on the Context anchor so nav offset leaves the heading visible when linked

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693325c79d9c832d85f781296ed6071c)

## Summary by Sourcery

Adjust layout and scrolling behavior around the Context section heading to improve readability and in-page navigation.

Enhancements:
- Add vertical margin above the Context section heading to prevent visual overlap with preceding content.
- Set a scroll margin on the Context section anchor so that the heading remains visible when navigated to via in-page links.