### PR TITLE
Update hero headline and subheadline

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,9 +1058,9 @@
                     </div>
 
                     <h1>
-                        Reduce observability chaos at the edge. <span class="hl">Govern noisy, unstructured logs before they hit your sinks and stop schema drift with CI + runtime guardrails.</span>
+                        Govern logs before they hit your sinks.
                     </h1>
-                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">Cerbi helps SRE, DevOps, and .NET teams reduce noise before ingestion, make redaction automatic, and prevent misconfiguration-led ingestion surprises. We validate every payload where it’s produced, keep policy versioned outside the codebase, and score governance posture release-to-release—without changing your logger or routing.</p>
+                    <p class="sub" style="font-size:18px;max-width:700px;margin:0 auto">CI + runtime guardrails for structured logging and automatic redaction—without changing your logger or routing.</p>
 
                     <!-- Dual CTAs -->
                     <div class="hero-ctas">


### PR DESCRIPTION
## Summary
- replace the hero headline with updated governing logs message
- refresh the subheadline to emphasize CI/runtime guardrails and automatic redaction

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933334e1b40832da2b72151bf4c75b9)

## Summary by Sourcery

Update the homepage hero messaging to emphasize governing logs before they reach sinks, with a concise headline and subheadline.

New Features:
- Revise the hero headline to highlight governing logs prior to ingestion.
- Refresh the hero subheadline to focus on CI/runtime guardrails for structured logging and automatic redaction.