### PR TITLE
Add spacing before context section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1157,7 +1157,11 @@
             </div>
         </section>
 
-        <section id="why-redaction" class="container section" style="background:var(--panel);border-radius:18px;padding:56px 42px;border:1px solid rgba(20,40,72,.08)">
+        <section
+            id="why-redaction"
+            class="container section mt-10 md:mt-12"
+            style="background:var(--panel);border-radius:18px;padding:56px 42px;border:1px solid rgba(20,40,72,.08)"
+        >
             <div class="eyebrow">Context</div>
             <h2>Why <span class="hl">Redaction Alone Isn’t Enough</span></h2>
             <p class="lead">Cerbi complements Serilog, NLog, and Microsoft.Extensions.Logging by governing payloads before they hit your sinks. Instead of relying on ad-hoc masking, Cerbi combines policy, analyzers, runtime guards, versioning, and scoring so redaction is one layer in a governed pipeline you keep routing.</p>


### PR DESCRIPTION
## Summary
- add responsive top margin before the "Why Redaction Alone Isn’t Enough" section to separate it from the hero metrics
- keep section styling intact while ensuring the transition feels deliberate

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693352327128832da389459cdc6f0219)

## Summary by Sourcery

Enhancements:
- Introduce responsive top margin utility classes to the context section to improve layout spacing across screen sizes.