### PR TITLE
Adjust hero subheadline spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1094,7 +1094,7 @@
     <main id="main">
         <section class="hero container relative" id="top" aria-label="Hero">
             <div class="hero-layout flex flex-col items-center gap-10 md:gap-12">
-                <div class="hero-main flex w-full flex-col items-center text-center gap-6 md:gap-7">
+                <div class="hero-main flex w-full flex-col items-center text-center">
                     <div class="chip-row justify-center gap-2 md:gap-3" role="list" aria-label="High level features">
                         <span class="chip">Governance + Scoring</span>
                         <span class="chip">Schema Consistency</span>
@@ -1104,12 +1104,12 @@
                         <span class="chip">Tenant-Hosted</span>
                     </div>
 
-                    <h1>
+                    <h1 class="mb-4">
                         Govern logs before they hit your sinks.
                     </h1>
-                    <p class="sub text-base md:text-lg max-w-3xl mx-auto">CI + runtime guardrails for structured logging and automatic redaction—without changing your logger or routing.</p>
+                    <p class="sub text-base md:text-lg max-w-3xl mx-auto mb-8">CI + runtime guardrails for structured logging and automatic redaction—without changing your logger or routing.</p>
 
-                    <div class="hero-ctas flex w-full flex-wrap justify-center gap-3" role="group" aria-label="Primary calls to action">
+                    <div class="hero-ctas flex w-full flex-wrap justify-center gap-3 mb-6" role="group" aria-label="Primary calls to action">
                         <a href="#quickstart" class="btn btn-primary btn-large">
                             ⚡ Try CerbiStream in 60 Seconds
                         </a>


### PR DESCRIPTION
## Summary
- Keep the hero headline and subheadline together in the centered hero container
- Add consistent bottom margins to the headline, subheadline, and CTA group for cleaner rhythm

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693354ce9210832da3193911802ed877)

## Summary by Sourcery

Adjust hero section spacing to tighten grouping of the headline and subheadline while establishing consistent vertical rhythm with the calls to action.

Enhancements:
- Refine hero layout by removing extra flex gap between content blocks and relying on explicit margins for spacing.
- Add consistent bottom margins to the hero headline, subheadline, and CTA group to improve visual hierarchy and readability.