### PR TITLE
Adjust NuGet stat spacing and section margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,7 +669,7 @@
         }
 
         .nuget-inline-stat {
-            margin-top: 12px;
+            margin: 12px auto 0;
             font-size: 0.7rem;
             color: rgba(255, 255, 255, 0.7);
             text-align: center;
@@ -1192,7 +1192,7 @@
 
         <section
             id="why-redaction"
-            class="container section mt-10 md:mt-12"
+            class="container section mt-8 md:mt-10"
             style="background:var(--panel);border-radius:18px;padding:56px 42px;border:1px solid rgba(20,40,72,.08)"
         >
             <div class="eyebrow">Context</div>


### PR DESCRIPTION
## Summary
- remove extra bottom margin from the NuGet inline stat block to tighten spacing
- align the following section with consistent `mt-8 md:mt-10` top margin

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693354f2ea9c832d9eb0e58cc2a1c3e7)

## Summary by Sourcery

Tighten layout spacing for NuGet inline statistics and the subsequent content section.

Enhancements:
- Adjust NuGet inline stat block margins to center it and remove extra bottom spacing.
- Reduce the top margin for the 'why-redaction' section for more consistent vertical spacing across breakpoints.