### PR TITLE
Align spacing between stats and persona rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
 
         /* Hero Metrics */
         .metrics-shell {
-            margin: 40px auto 32px;
+            margin: 0 auto;
             max-width: 1080px;
             background: linear-gradient(135deg, rgba(255,77,0,.1) 0%, rgba(15,99,255,.12) 100%);
             border-radius: 22px;
@@ -600,6 +600,7 @@
         .section-tight { padding: 2rem 0; }
         .py-14 { padding-top: 3.5rem; padding-bottom: 3.5rem; }
         .py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+        .mt-10 { margin-top: 2.5rem; }
         .space-y-6 > * + * { margin-top: 1.5rem; }
         .space-y-8 > * + * { margin-top: 2rem; }
         @media (min-width: 768px) {
@@ -607,6 +608,7 @@
             .section-tight { padding: 3rem 0; }
             .md\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
             .md\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+            .md\:mt-12 { margin-top: 3rem; }
         }
         #why-redaction {
             margin-top: 0;
@@ -681,7 +683,7 @@
 
         .scroll-target { scroll-margin-top: calc(var(--nav-h) + 16px); }
 
-        .persona-nav { padding: 40px 0; margin: 32px auto; text-align: center; }
+        .persona-nav { text-align: center; }
         .persona-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; justify-items: center; }
         .persona-card { text-decoration: none; color: inherit; display: grid; gap: 6px; align-content: start; padding: 16px 18px; border-radius: 14px; border: 1px solid rgba(20,40,72,.12); background: linear-gradient(135deg, rgba(255,77,0,.06), rgba(15,99,255,.04)); box-shadow: 0 14px 36px rgba(12,22,44,0.08); transition: transform .15s ease, box-shadow .2s ease, border-color .2s ease; max-width: 360px; width: 100%; }
         .persona-card:hover { transform: translateY(-1px); box-shadow: 0 18px 44px rgba(12,22,44,0.12); border-color: color-mix(in srgb, var(--brand) 30%, rgba(20,40,72,.12)); }
@@ -1117,29 +1119,31 @@
                         Founder-led pilots with hands-on implementation support, governance scorecards, and weekly working sessions for platform teams.
                     </p>
 
-                    <div class="hero-stats-row">
-                        <!-- Executive Stats Banner -->
-                        <div id="heroMetrics" class="metrics-shell">
-                            <div class="metrics-grid">
-                                <article class="metric-card">
-                                    <div class="metric-number">40%</div>
-                                    <div class="metric-label">Log spend eliminated</div>
-                                    <p class="metric-note">Median reduction in paid log volume for early adopters in the first 90 days.</p>
-                                </article>
-                                <article class="metric-card">
-                                    <div class="metric-number">95%</div>
-                                    <div class="metric-label">First-audit pass rate</div>
-                                    <p class="metric-note">Compliance checks passed on first audit when teams enforced Cerbi governance profiles.</p>
-                                </article>
-                                <article class="metric-card">
-                                    <div class="metric-number">3x</div>
-                                    <div class="metric-label">Faster incident response</div>
-                                    <p class="metric-note">Time-to-resolution improvement after instrumenting runbooks with governed, searchable logs.</p>
-                                </article>
+                    <div class="mt-10 md:mt-12">
+                        <div class="hero-stats-row">
+                            <!-- Executive Stats Banner -->
+                            <div id="heroMetrics" class="metrics-shell">
+                                <div class="metrics-grid">
+                                    <article class="metric-card">
+                                        <div class="metric-number">40%</div>
+                                        <div class="metric-label">Log spend eliminated</div>
+                                        <p class="metric-note">Median reduction in paid log volume for early adopters in the first 90 days.</p>
+                                    </article>
+                                    <article class="metric-card">
+                                        <div class="metric-number">95%</div>
+                                        <div class="metric-label">First-audit pass rate</div>
+                                        <p class="metric-note">Compliance checks passed on first audit when teams enforced Cerbi governance profiles.</p>
+                                    </article>
+                                    <article class="metric-card">
+                                        <div class="metric-number">3x</div>
+                                        <div class="metric-label">Faster incident response</div>
+                                        <p class="metric-note">Time-to-resolution improvement after instrumenting runbooks with governed, searchable logs.</p>
+                                    </article>
+                                </div>
+                                <p class="muted" style="text-align:center;margin:14px auto 0;max-width:780px;font-size:13px">
+                                    Figures are illustrative pilot outcomes from governed schemas, redaction posture, and audit evidence; your pipeline and controls will change results.
+                                </p>
                             </div>
-                            <p class="muted" style="text-align:center;margin:14px auto 0;max-width:780px;font-size:13px">
-                                Figures are illustrative pilot outcomes from governed schemas, redaction posture, and audit evidence; your pipeline and controls will change results.
-                            </p>
                         </div>
                     </div>
 
@@ -1216,23 +1220,25 @@
             </div>
         </section>
 
-        <section class="container section persona-nav" aria-label="Persona navigation">
-            <div class="persona-grid">
-                <a class="persona-card" href="#use-cases">
-                    <div class="persona-title">For CTOs &amp; VP Engineering</div>
-                    <p class="persona-desc">Score governance outcomes to prove improvement, and see cost and compliance impact from governed schemas and redaction posture without swapping log vendors.</p>
-                    <span class="persona-cta">Jump to outcomes →</span>
-                </a>
-                <a class="persona-card" href="#ecosystem-explore" data-scroll-target="#ecosystem-explore">
-                    <div class="persona-title">For Developers &amp; Platform Teams</div>
-                    <p class="persona-desc">Skip to the Quick Start, NuGet install, and see how Cerbi governs payloads while you keep your agents, collectors, and sinks.</p>
-                    <span class="persona-cta">Explore the stack →</span>
-                </a>
-                <a class="persona-card" href="#compliance">
-                    <div class="persona-title">For Security, Risk &amp; Compliance</div>
-                    <p class="persona-desc">Review governance controls, redaction posture scoring, and CI/runtime enforcement.</p>
-                    <span class="persona-cta">View controls →</span>
-                </a>
+        <section class="container section" aria-label="Persona navigation">
+            <div class="persona-nav mt-10 md:mt-12">
+                <div class="persona-grid">
+                    <a class="persona-card" href="#use-cases">
+                        <div class="persona-title">For CTOs &amp; VP Engineering</div>
+                        <p class="persona-desc">Score governance outcomes to prove improvement, and see cost and compliance impact from governed schemas and redaction posture without swapping log vendors.</p>
+                        <span class="persona-cta">Jump to outcomes →</span>
+                    </a>
+                    <a class="persona-card" href="#ecosystem-explore" data-scroll-target="#ecosystem-explore">
+                        <div class="persona-title">For Developers &amp; Platform Teams</div>
+                        <p class="persona-desc">Skip to the Quick Start, NuGet install, and see how Cerbi governs payloads while you keep your agents, collectors, and sinks.</p>
+                        <span class="persona-cta">Explore the stack →</span>
+                    </a>
+                    <a class="persona-card" href="#compliance">
+                        <div class="persona-title">For Security, Risk &amp; Compliance</div>
+                        <p class="persona-desc">Review governance controls, redaction posture scoring, and CI/runtime enforcement.</p>
+                        <span class="persona-cta">View controls →</span>
+                    </a>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add shared mt-10/md:mt-12 spacing utilities and apply them to the stats and persona rows for consistent layout
- remove redundant margins and padding from the metrics and persona containers to keep the rounded outlines aligned with adjacent sections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933619d4aa0832d83b017fb0da9b68a)

## Summary by Sourcery

Align vertical spacing and container structure for the hero stats and persona sections to create a consistent layout.

Enhancements:
- Introduce shared responsive margin-top utility classes and apply them to the hero stats and persona sections for consistent spacing across breakpoints.
- Simplify metrics and persona container styles by removing redundant margins and padding so their rounded outlines align with adjacent sections.