### PR TITLE
Tighten hero spacing and reduce vertical padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
             max-width: 1080px;
             background: linear-gradient(135deg, rgba(255,77,0,.1) 0%, rgba(15,99,255,.12) 100%);
             border-radius: 22px;
-            padding: clamp(22px, 4vw, 38px);
+            padding: clamp(18px, 3.4vw, 32px);
             border: 1px solid color-mix(in srgb, var(--brand) 32%, transparent);
             box-shadow: 0 18px 40px rgba(12, 22, 44, 0.12);
         }
@@ -91,16 +91,16 @@
         .metrics-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-            gap: clamp(18px, 3vw, 24px);
+            gap: clamp(14px, 2.6vw, 20px);
         }
 
         .metric-card {
             background: rgba(255, 255, 255, 0.9);
             border-radius: 16px;
-            padding: clamp(16px, 2.4vw, 22px);
+            padding: clamp(14px, 2vw, 20px);
             border: 1px solid rgba(24, 34, 53, 0.12);
             display: grid;
-            gap: 8px;
+            gap: 6px;
             align-content: start;
             transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease, z-index 0ms;
             will-change: transform;
@@ -213,21 +213,21 @@
             display: flex;
             flex-wrap: wrap;
             justify-content: center;
-            gap: 12px;
+            gap: clamp(10px, 2vw, 14px);
             width: 100%;
             margin: 0 auto;
         }
 
         .btn-large {
-            padding: 14px 28px;
+            padding: 13px 24px;
             font-size: 17px;
             font-weight: 700;
             display: inline-flex;
             align-items: center;
             gap: 8px;
-            flex: 1 1 240px;
-            min-width: 240px;
-            min-height: 56px;
+            flex: 1 1 220px;
+            min-width: 220px;
+            min-height: 52px;
             justify-content: center;
         }
 
@@ -549,7 +549,7 @@
 
         .hero {
             position: relative;
-            padding: 20px 0 8px;
+            padding: clamp(12px, 2vw, 20px) 0 clamp(10px, 2vw, 16px);
             isolation: isolate;
         }
         .hero-layout {
@@ -557,12 +557,12 @@
             flex-direction: column;
             position: relative;
             z-index: 1;
-            gap: clamp(22px, 4vw, 32px);
+            gap: clamp(18px, 3vw, 26px);
         }
         .hero-main {
             display: flex;
             flex-direction: column;
-            gap: clamp(18px, 3vw, 26px);
+            gap: clamp(14px, 2.4vw, 22px);
         }
         .hero::before {
             content: "";
@@ -580,7 +580,7 @@
             justify-content: center;
             column-gap: 10px;
             row-gap: 8px;
-            margin: 0 auto clamp(12px, 2.5vw, 20px);
+            margin: 0 auto clamp(8px, 2vw, 18px);
             max-width: min(960px, 100%);
         }
         .chip { background: #e8f0ff; color: #1b3159; padding: 6px 10px; border-radius: 999px; border: 1px solid rgba(20,40,72,.12) }
@@ -593,22 +593,22 @@
             .chip { padding: 5px 9px; font-size: 13px; }
         }
         .hl { color: var(--brand) }
-        .hero h1 { margin: 0 0 1rem; font-size: clamp(26px,4.6vw,44px); line-height: 1.1; background: linear-gradient(90deg, var(--brand), #ff8443 35%, #0f63ff 80%); -webkit-background-clip: text; background-clip: text; color: transparent; min-height: 2.4em; }
-        .sub { color: var(--muted); max-width: 70ch; min-height: 2.2em; margin: 0 0 2rem; }
+        .hero h1 { margin: 0 0 .85rem; font-size: clamp(26px,4.6vw,44px); line-height: 1.08; background: linear-gradient(90deg, var(--brand), #ff8443 35%, #0f63ff 80%); -webkit-background-clip: text; background-clip: text; color: transparent; min-height: 2.4em; }
+        .sub { color: var(--muted); max-width: 70ch; min-height: 2.2em; margin: 0 0 1.35rem; }
         .hero-headings { text-align: center; }
-        .section { padding: 3.5rem 0; }
-        .section-tight { padding: 2rem 0; }
-        .py-14 { padding-top: 3.5rem; padding-bottom: 3.5rem; }
-        .py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-        .mt-10 { margin-top: 2.5rem; }
+        .section { padding: clamp(2.5rem, 5.5vw, 3.5rem) 0; }
+        .section-tight { padding: clamp(1.5rem, 4vw, 2.2rem) 0; }
+        .py-14 { padding-top: 3.25rem; padding-bottom: 3.25rem; }
+        .py-8 { padding-top: 1.75rem; padding-bottom: 1.75rem; }
+        .mt-10 { margin-top: 2rem; }
         .space-y-6 > * + * { margin-top: 1.5rem; }
         .space-y-8 > * + * { margin-top: 2rem; }
         @media (min-width: 768px) {
-            .section { padding: 5rem 0; }
-            .section-tight { padding: 3rem 0; }
+            .section { padding: clamp(3.25rem, 6vw, 4.25rem) 0; }
+            .section-tight { padding: clamp(2.4rem, 4.8vw, 3.2rem) 0; }
             .md\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
             .md\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-            .md\:mt-12 { margin-top: 3rem; }
+            .md\:mt-12 { margin-top: 2.5rem; }
         }
         #why-redaction {
             margin-top: 0;
@@ -640,7 +640,7 @@
             max-width: 1080px;
             margin: 0 auto;
             z-index: 1;
-            padding-inline: clamp(12px, 3vw, 22px);
+            padding-inline: clamp(10px, 2.6vw, 20px);
         }
 
         .hero-stats-row {


### PR DESCRIPTION
## Summary
- tighten hero spacing with smaller gaps and CTA sizing for a more compact fold
- trim padding on section wrappers and hero chips to reduce wasted vertical space
- adjust metrics layout spacing for cleaner, tighter cards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693363bf7b48832dba56d4e8241cbcb9)

## Summary by Sourcery

Tighten hero and section layout spacing to create a more compact above-the-fold experience and reduce vertical whitespace across the page.

Enhancements:
- Reduce padding and gaps in the hero container, layout, headings, and chips for a denser hero presentation.
- Trim padding and gaps in metrics grid and metric cards to produce tighter, more compact stat cards.
- Slightly shrink large CTA button sizing and chip/button spacing to better fit within the tightened layout.
- Adjust global section, margin, and container padding utilities (including responsive variants) to lower overall vertical rhythm and whitespace.