### PR TITLE
Center hero subheading and constrain hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,6 +569,21 @@
             flex-direction: column;
             gap: clamp(12px, 2.2vw, 22px);
         }
+
+        .hero-main > *:not(.hero-banner) {
+            width: min(1000px, 100%);
+            margin-inline: auto;
+        }
+
+        .hero-main h1,
+        .hero-main .sub {
+            text-align: center;
+            margin-inline: auto;
+        }
+
+        .hero-main .sub {
+            max-width: 48ch;
+        }
         .hero::before {
             content: "";
             position: absolute;


### PR DESCRIPTION
## Summary
- constrain hero section elements to a centered readable width while keeping the banner full width
- explicitly center the hero subheading beneath the primary headline with a comfortable line width

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ac355bd0832db3c588228324d2ee)

## Summary by Sourcery

Center and constrain the hero section content for improved readability while keeping the banner full width.

Enhancements:
- Constrain non-banner hero content to a centered maximum width within the hero section.
- Center-align the hero headline and subheading text and limit the subheading line width for better readability.