### PR TITLE
Add pricing and licensing anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1272,6 +1272,50 @@
             </div>
         </section>
 
+        <section id="pricing" class="container section">
+            <div class="eyebrow">Licensing & Plans</div>
+            <h2>How we <span class="hl">license</span> Cerbi</h2>
+            <p class="lead">NuGet packages &amp; governance runtime: free &amp; OSS (MIT). CerbiShield &amp; Scoring: paid plans via Azure Marketplace or private offers.</p>
+
+            <div class="card" style="margin-bottom:18px;">
+                <p><strong>Quick split:</strong> install CerbiStream, analyzers, and governance runtime from NuGet under MIT; subscribe to CerbiShield + Scoring when you want managed RBAC, audit history, scorecards, and SLAs.</p>
+            </div>
+
+            <div class="grid" style="margin-top:10px;">
+                <article class="col-4 card">
+                    <h3>Starter / Team</h3>
+                    <p class="muted">Anchor price: <strong>$690/month</strong> via Azure Marketplace for up to 5 governed apps; includes CerbiShield dashboards and Scoring.</p>
+                    <ul>
+                        <li>Unlimited OSS NuGet packages (MIT)</li>
+                        <li>5 governed apps with relax-mode rollout</li>
+                        <li>Email support and monthly check-ins</li>
+                    </ul>
+                </article>
+
+                <article class="col-4 card">
+                    <h3>Growth</h3>
+                    <p class="muted">Anchor price: <strong>$2,400/month</strong> via Azure Marketplace for up to 25 governed apps; add-ons billed per app.</p>
+                    <ul>
+                        <li>NuGet + runtime under MIT</li>
+                        <li>25 governed apps with RBAC &amp; audit history</li>
+                        <li>Priority support and rollout planning</li>
+                    </ul>
+                </article>
+
+                <article class="col-4 card">
+                    <h3>Enterprise</h3>
+                    <p class="muted"><strong>Contact us</strong>; starts at <strong>$6,500/month</strong> via Azure Marketplace or private offer.</p>
+                    <ul>
+                        <li>Unlimited governed apps &amp; scoring volume</li>
+                        <li>Private networking, SSO, and SOC2 package</li>
+                        <li>Named TAM, architecture reviews, and SLAs</li>
+                    </ul>
+                </article>
+            </div>
+
+            <p class="k" style="margin-top:18px">We’ll refine pricing in the next section—this anchor keeps procurement fast. If you need a custom offer, we’ll route through Azure Marketplace or craft a private deal.</p>
+        </section>
+
         <section class="container section capabilities" aria-label="Capabilities">
             <div class="capabilities-head">
                 <div class="eyebrow">Capabilities</div>


### PR DESCRIPTION
## Summary
- Add licensing and pricing section clarifying OSS NuGet packages versus paid CerbiShield/Scoring
- Introduce Starter/Team, Growth, and Enterprise tier cards with anchor pricing via Azure Marketplace
- Note procurement guidance for marketplace and private offers

## Testing
- Not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933c177dd0c832dbed157bb9612933b)

## Summary by Sourcery

Add a new licensing and pricing section to the homepage describing how Cerbi is licensed and outlining commercial plans.

New Features:
- Introduce a dedicated licensing and plans section explaining the split between free OSS NuGet/runtime components and paid CerbiShield/Scoring offerings.
- Add Starter/Team, Growth, and Enterprise plan cards with indicative pricing and key inclusions for governed applications.
- Clarify procurement options, including purchasing via Azure Marketplace and arranging private offers for custom deals.