### PR TITLE
Add product lineup table to Cerbi overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -1428,6 +1428,19 @@
             <div class="eyebrow">Overview</div>
             <h2>Cerbi — <span class="hl">Brief Overview</span></h2>
             <p class="lead">CerbiStream is a governance-first logging layer for .NET that validates, redacts, and tags every log event before it hits your log platforms. Instead of shipping “whatever the app logs” into expensive platforms, Cerbi enforces JSON profiles so only clean, compliant, ML-ready data flows downstream. CerbiShield is the tenant-hosted governance brain and scorecard layer that defines, versions, and deploys those profiles with RBAC and audit history—customers own the infrastructure and data plane while policy stays outside code. The Scoring API is the governance scoring engine that tracks posture over time. Together, they turn logging from an ungoverned cost center into an auditable, measurable part of your architecture without ever routing your traffic.</p>
+            <div class="card" style="padding:12px;overflow-x:auto">
+                <table aria-label="Cerbi product lineup" class="table">
+                    <thead>
+                        <tr><th>Product</th><th>Type</th><th>Where it runs</th><th>License</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><strong>CerbiStream</strong></td><td>.NET logging library</td><td>In your apps/services</td><td>OSS (MIT)</td></tr>
+                        <tr><td><strong>Cerbi.Governance.Runtime</strong></td><td>Engine</td><td>In your apps/services</td><td>OSS (MIT)</td></tr>
+                        <tr><td><strong>CerbiShield</strong></td><td>Governance brain + dashboards</td><td>In your Azure tenant</td><td>Commercial</td></tr>
+                        <tr><td><strong>Scoring API</strong></td><td>Governance scoring service</td><td>In your Azure tenant</td><td>Commercial</td></tr>
+                    </tbody>
+                </table>
+            </div>
             <div class="card video-card-shell" data-video-card="brief-overview"></div>
         </section>
 


### PR DESCRIPTION
## Summary
- add a concise product lineup table near the Cerbi brief overview
- clarify product types, hosting locations, and licensing at a glance

## Testing
- not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933c1f1fb90832d9e11fa9721ff1701)

## Summary by Sourcery

New Features:
- Introduce an overview table summarizing Cerbi products, their types, hosting locations, and licensing in the Cerbi brief overview section.