### PR TITLE
Make audit savings segment black

### DIFF
--- a/index.html
+++ b/index.html
@@ -1010,7 +1010,7 @@
         .segment-ingest { background: linear-gradient(135deg, #ffe6da 0%, #ff8a5c 100%); }
         .segment-retention { background: linear-gradient(135deg, #e4ecff 0%, #6ca2ff 100%); }
         .segment-engineering { background: linear-gradient(135deg, #def6f0 0%, #3cc9aa 100%); }
-        .segment-audit { background: linear-gradient(135deg, #dbe2f1 0%, #2f4a73 100%); color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.28); }
+        .segment-audit { background: linear-gradient(135deg, #000000 0%, #111111 100%); color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.28); }
         .savings-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; }
         .savings-item { background: var(--panel-2); border-radius: 12px; padding: 14px; border: 1px solid rgba(20,40,72,.08); }
         .savings-item .percent { display: inline-block; font-weight: 800; color: var(--brand); margin-bottom: 4px; }


### PR DESCRIPTION
## Summary
- update the savings breakdown audit segment styling to use a black gradient
- keep legibility with existing text styling

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933c67e88dc832d9b54a0522c830289)

## Summary by Sourcery

Enhancements:
- Restyle the audit savings segment to use a dark black gradient background consistent with existing text contrast.