### PR TITLE
Refine homepage layout and pricing

### DIFF
--- a/index.html
+++ b/index.html
@@ -719,7 +719,7 @@
         .hero h1 { margin: 0 0 .35rem; font-size: clamp(32px,5vw,50px); line-height: 1.08; color: var(--text-strong); letter-spacing: -0.35px; }
         .sub { color: var(--muted); max-width: 70ch; min-height: 2.2em; margin: 0; font-size: clamp(17px,2vw,20px); }
         .hero-headings { text-align: center; }
-        .section { padding-block: clamp(40px, 7vw, 80px); }
+        .section { padding-block: clamp(48px, 7vw, 80px); }
         .section > :first-child { margin-top: 0; }
         .py-14 { padding-top: 3.25rem; padding-bottom: 3.25rem; }
         .py-8 { padding-top: 1.75rem; padding-bottom: 1.75rem; }
@@ -728,10 +728,10 @@
         .space-y-8 > * + * { margin-top: 2rem; }
         .space-y-10 > * + * { margin-top: 2.5rem; }
         @media (max-width: 1024px) {
-            .section { padding-block: clamp(40px, 9vw, 72px); }
+            .section { padding-block: clamp(48px, 10vw, 72px); }
         }
         @media (max-width: 640px) {
-            .section { padding-block: clamp(40px, 10vw, 60px); }
+            .section { padding-block: clamp(48px, 11vw, 64px); }
             .hero-banner figcaption { font-size: 13px; }
         }
         @media (min-width: 768px) {
@@ -762,6 +762,111 @@
         .card h3 { font-size: clamp(16px,2.1vw,22px); overflow-wrap: anywhere }
         .card p, .card li { overflow-wrap: anywhere; hyphens: auto }
         .card ul { padding-left: 18px; margin: 8px 0 }
+
+        .space-y-2 > * + * { margin-top: 8px; }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 8px 10px;
+            border-radius: 999px;
+            background: color-mix(in srgb, var(--brand) 10%, white 90%);
+            color: var(--text-strong);
+            border: 1px solid color-mix(in srgb, var(--brand) 24%, rgba(20,40,72,.14));
+            font-weight: 600;
+            font-size: 14px;
+        }
+
+        .pricing-headline {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 14px;
+            flex-wrap: wrap;
+        }
+
+        .pricing-badges { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+
+        .pricing-grid {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 16px;
+            margin-top: 18px;
+        }
+
+        .pricing-card {
+            background: var(--panel);
+            border: 1px solid rgba(20,40,72,.12);
+            border-radius: var(--radius);
+            padding: 18px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            min-height: 100%;
+            box-shadow: 0 10px 30px rgba(20,40,72,.06);
+        }
+
+        .pricing-card ul { margin: 0; display: grid; gap: 6px; padding-left: 18px; }
+
+        .pricing-meta { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+        .pricing-limit { color: var(--brand); font-weight: 800; }
+        .pricing-price { font-size: 30px; font-weight: 800; letter-spacing: -0.3px; }
+
+        .pricing-most-popular {
+            border: 2px solid var(--brand);
+            box-shadow: 0 18px 40px rgba(255,77,0,0.12);
+            position: relative;
+        }
+
+        .pricing-most-popular::before {
+            content: "Most Popular";
+            position: absolute;
+            top: -14px;
+            right: 12px;
+            background: var(--brand);
+            color: white;
+            padding: 6px 10px;
+            border-radius: 999px;
+            font-size: 13px;
+            font-weight: 700;
+        }
+
+        .app-note { margin: 12px 0 2px; color: var(--muted); font-size: 14px; }
+
+        .pricing-compare {
+            margin-top: 22px;
+            border: 1px solid rgba(20,40,72,.12);
+            border-radius: var(--radius);
+            padding: 14px;
+            background: var(--panel-2);
+            overflow-x: auto;
+        }
+
+        .compare-grid {
+            display: grid;
+            grid-template-columns: 1.4fr repeat(4, 1fr);
+            gap: 6px 10px;
+            align-items: center;
+            min-width: 640px;
+        }
+
+        .compare-header { font-weight: 800; color: var(--text-strong); }
+        .compare-tier { text-align: center; }
+        .compare-row { padding-block: 6px; border-top: 1px solid rgba(20,40,72,.08); }
+        .compare-label { font-weight: 600; }
+        .compare-cell { text-align: center; font-weight: 700; }
+
+        @media (max-width: 1100px) {
+            .pricing-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        }
+
+        @media (max-width: 720px) {
+            .pricing-grid { grid-template-columns: 1fr; }
+            .pricing-headline { flex-direction: column; }
+            .pricing-badges { justify-content: flex-start; }
+        }
+
         .mono { font-family: "Roboto Mono", ui-monospace, Menlo, Consolas, monospace }
 
         .hero-layout {
@@ -1356,260 +1461,429 @@
                 </div>
             </div>
         </section>
-
-        <section id="pricing" class="container section">
-            <div class="eyebrow">Licensing & Plans</div>
-            <h2>How we <span class="hl">license</span> Cerbi</h2>
-            <p class="lead">CerbiStream (NuGet analyzers + runtime guards) stays free and MIT. CerbiShield + Scoring add governed dashboards, API access, deployment history, and scorecards—procured via Azure Marketplace or private offer.</p>
-
-            <div class="card" style="margin-bottom:18px;">
-                <p><strong>Governance first:</strong> We don’t route logs. Cerbi standardizes schemas, tags/redacts risky fields, and scores governance posture so you reduce paid log noise before it reaches your existing tools.</p>
-            </div>
-
-            <h3 style="margin-top:10px;">Section 1: Preview pricing plan blurbs</h3>
-            <p class="muted" style="margin-bottom:10px;">Provisional pricing for Marketplace listing drafts; final rates may change.</p>
-            <div class="grid" style="--cols:2;gap:16px;">
-                <article class="card">
-                    <div class="flex items-center justify-between">
-                        <h4>Plan 1: Free</h4>
-                        <span class="chip">$0</span>
-                    </div>
-                    <p class="muted">For individual engineers validating CerbiStream and runtime governance on a single app.</p>
-                    <ul>
-                        <li>CerbiStream SDK + analyzers (MIT) with 1 governed app</li>
-                        <li>Governance rule authoring with JSON import/export</li>
-                        <li>Runtime tagging/redaction concepts to shrink noisy payloads</li>
-                        <li>Validation playground for pre-production checks</li>
-                        <li>Basic retention/history with local audit trail</li>
-                    </ul>
-                </article>
-                <article class="card">
-                    <div class="flex items-center justify-between">
-                        <h4>Plan 2: Basic</h4>
-                        <span class="chip">$99/mo</span>
-                    </div>
-                    <p class="muted">For small teams adding light governance with simple RBAC and more apps.</p>
-                    <ul>
-                        <li>Up to 5 governed apps with compile-time analyzer enforcement</li>
-                        <li>Email-based RBAC + audit logs for policy changes</li>
-                        <li>Governance-as-code via JSON export/import for CI</li>
-                        <li>Deployment targets per app for test + prod parity</li>
-                        <li>Templates/starter kits (not certified compliance)</li>
-                    </ul>
-                </article>
-                <article class="card">
-                    <div class="flex items-center justify-between">
-                        <h4>Plan 3: Pro <span class="chip" style="background:var(--accent);color:var(--bg);">Recommended</span></h4>
-                        <span class="chip">$299/mo</span>
-                    </div>
-                    <p class="muted">For platform teams standardizing schemas across multiple services with managed RBAC and history.</p>
-                    <ul>
-                        <li>Up to 20 governed apps with SSO and role depth for squads</li>
-                        <li>Runtime enforcement with redaction + tagging to cut vendor log volume</li>
-                        <li>Governance rule versioning with deployment history</li>
-                        <li>Validation playground + scoring API visibility</li>
-                        <li>Multiple deployment targets per app with rollback metadata</li>
-                    </ul>
-                </article>
-                <article class="card">
-                    <div class="flex items-center justify-between">
-                        <h4>Plan 4: Scale</h4>
-                        <span class="chip">$599/mo</span>
-                    </div>
-                    <p class="muted">For fast-growing companies aligning dozens of services to governed schemas and redaction guardrails.</p>
-                    <ul>
-                        <li>Up to 50 governed apps with hierarchical RBAC and approval flows</li>
-                        <li>Advanced governance-as-code with policy promotion between environments</li>
-                        <li>Expanded audit logs + retention for change tracing</li>
-                        <li>Deployment targets per app covering regional footprints</li>
-                        <li>Governed reporting hooks (PDF/JSON-ready) for leadership reviews</li>
-                    </ul>
-                </article>
-                <article class="card" style="grid-column:span 2;">
-                    <div class="flex items-center justify-between">
-                        <h4>Plan 5: Enterprise</h4>
-                        <span class="chip">Private offer</span>
-                    </div>
-                    <p class="muted">For regulated orgs needing private networking, deep RBAC, and procurement-ready reporting.</p>
-                    <ul>
-                        <li>Custom app limits with SSO, SCIM, and fine-grained roles</li>
-                        <li>Enterprise audit logs, long-term retention, and deployment attestations</li>
-                        <li>Governance rule authoring + JSON pipelines with change approvals</li>
-                        <li>Reporting exports (PDF/JSON) for internal reviews—not certified compliance</li>
-                        <li>Architecture support to reduce paid log noise before vendor ingestion</li>
-                    </ul>
-                </article>
-            </div>
-
-            <h3 style="margin-top:28px;">Section 2: Price-agnostic plan blurbs</h3>
-            <div class="grid" style="--cols:2;gap:16px;">
-                <article class="card">
-                    <h4>Plan 1: Free</h4>
-                    <p class="muted">For solo builders proving out CerbiStream + CerbiShield on one app with baseline governance.</p>
-                    <ul>
-                        <li>1 governed app with MIT-licensed CerbiStream and analyzers</li>
-                        <li>Governance rule editing plus JSON import/export</li>
-                        <li>Validation playground and runtime tagging/redaction patterns</li>
-                        <li>Starter templates (not certified compliance)</li>
-                        <li>Basic audit history for change awareness</li>
-                    </ul>
-                </article>
-                <article class="card">
-                    <h4>Plan 2: Basic</h4>
-                    <p class="muted">For small teams adopting governance-as-code with lightweight RBAC and app headroom.</p>
-                    <ul>
-                        <li>Up to 5 apps with analyzer alignment and CI blocks for drift</li>
-                        <li>Email/SSO choice for simple access control</li>
-                        <li>Deployment targets per app (test + prod)</li>
-                        <li>Audit logs with short retention</li>
-                        <li>Templates/starter kits to speed policy definition</li>
-                    </ul>
-                </article>
-                <article class="card">
-                    <h4>Plan 3: Pro <span class="chip" style="background:var(--accent);color:var(--bg);">Recommended</span></h4>
-                    <p class="muted">For platform teams needing governed schemas, SSO, and traceable deployments across many services.</p>
-                    <ul>
-                        <li>Up to 20 apps with SSO + role-based approvals</li>
-                        <li>Runtime enforcement with redaction/tagging to trim log spend</li>
-                        <li>Governance versioning with per-target deployment history</li>
-                        <li>Scoring API for governance signals</li>
-                        <li>Extended retention and audit visibility</li>
-                    </ul>
-                </article>
-                <article class="card">
-                    <h4>Plan 4: Scale</h4>
-                    <p class="muted">For orgs coordinating governance across dozens of apps and regions with deeper RBAC.</p>
-                    <ul>
-                        <li>Up to 50 apps with hierarchical RBAC and approvals</li>
-                        <li>Multi-target deployments per app with promotion controls</li>
-                        <li>Advanced audit logs and retention options</li>
-                        <li>Governance rule automation through JSON pipelines</li>
-                        <li>Reporting hooks for leadership-ready summaries</li>
-                    </ul>
-                </article>
-                <article class="card" style="grid-column:span 2;">
-                    <h4>Plan 5: Enterprise</h4>
-                    <p class="muted">For enterprises seeking private offers, extended retention, and leadership-grade reporting.</p>
-                    <ul>
-                        <li>Custom app limits with SSO, SCIM, and advanced RBAC depth</li>
-                        <li>Full governance-as-code with approvals and JSON import/export</li>
-                        <li>Maximum retention, audit logs, and deployment attestations</li>
-                        <li>Reporting exports (PDF/JSON) for internal governance reviews</li>
-                        <li>Direct support to keep paid log noise low before vendor ingestion</li>
-                    </ul>
-                </article>
-            </div>
-
-            <h3 style="margin-top:28px;">Section 3: Feature matrix</h3>
-            <div class="card">
-                <table class="table" style="width:100%;font-size:14px;">
-                    <thead>
-                        <tr>
-                            <th>Capability</th>
-                            <th>Free</th>
-                            <th>Basic</th>
-                            <th>Pro <span class="chip" style="background:var(--accent);color:var(--bg);">Recommended</span></th>
-                            <th>Scale</th>
-                            <th>Enterprise</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>App limits</td>
-                            <td>1 app</td>
-                            <td>5 apps</td>
-                            <td>20 apps</td>
-                            <td>50 apps</td>
-                            <td>Custom</td>
-                        </tr>
-                        <tr>
-                            <td>SSO</td>
-                            <td>Not included</td>
-                            <td>Email/optional SSO</td>
-                            <td>Included</td>
-                            <td>Included with approvals</td>
-                            <td>Included with SCIM</td>
-                        </tr>
-                        <tr>
-                            <td>RBAC depth</td>
-                            <td>Single role</td>
-                            <td>Basic roles</td>
-                            <td>Team roles + approvals</td>
-                            <td>Hierarchical roles</td>
-                            <td>Fine-grained + custom</td>
-                        </tr>
-                        <tr>
-                            <td>Governance rule authoring + JSON import/export</td>
-                            <td>Included</td>
-                            <td>Included</td>
-                            <td>Versioned with history</td>
-                            <td>Versioned with promotions</td>
-                            <td>Versioned with approvals</td>
-                        </tr>
-                        <tr>
-                            <td>Validation playground</td>
-                            <td>Included</td>
-                            <td>Included</td>
-                            <td>Included + scoring signals</td>
-                            <td>Included + multi-target</td>
-                            <td>Included + enterprise telemetry</td>
-                        </tr>
-                        <tr>
-                            <td>Deployment targets per app</td>
-                            <td>1 target</td>
-                            <td>2 targets</td>
-                            <td>4 targets</td>
-                            <td>Regional targets</td>
-                            <td>Custom footprints</td>
-                        </tr>
-                        <tr>
-                            <td>Audit logs</td>
-                            <td>Local trail</td>
-                            <td>Short retention</td>
-                            <td>Extended retention</td>
-                            <td>Expanded retention + filters</td>
-                            <td>Long-term with export</td>
-                        </tr>
-                        <tr>
-                            <td>Retention/history</td>
-                            <td>Limited history</td>
-                            <td>30 days</td>
-                            <td>90 days</td>
-                            <td>180 days</td>
-                            <td>Custom</td>
-                        </tr>
-                        <tr>
-                            <td>Reporting (PDF/JSON)</td>
-                            <td>Not included</td>
-                            <td>Not included</td>
-                            <td>Not included</td>
-                            <td>Hooks for internal summaries</td>
-                            <td>Included (internal use)</td>
-                        </tr>
-                        <tr>
-                            <td>Templates/starter kits (not certified compliance)</td>
-                            <td>Included</td>
-                            <td>Included</td>
-                            <td>Included</td>
-                            <td>Included</td>
-                            <td>Included</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-
-            <h3 style="margin-top:28px;">Section 4: Marketplace plan highlights</h3>
-            <ul>
-                <li>Governance-as-code with Roslyn analyzers + runtime validators to block schema drift early.</li>
-                <li>Runtime tagging/redaction concepts to reduce paid log noise before vendor ingestion.</li>
-                <li>Scoring API surfaces governance signals for leadership-ready scorecards.</li>
-                <li>Versioned policies, deployment history, and audit logs to keep governance decisions traceable.</li>
-                <li>CerbiStream stays free as the entry point; CerbiShield adds dashboards, APIs, and support.</li>
+<section id="trust" class="container section panel-section">
+            <div class="eyebrow">Trust</div>
+            <h2>Control and confidence <span class="hl">by design</span></h2>
+            <p class="muted" style="max-width:820px;margin:0 auto 24px">Deployment, governance, and routing stay under your control. Cerbi enforces policy without taking over your log transport or locking you into a vendor path.</p>
+            <ul class="checked-list" style="grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px 18px">
+                <li><strong>Deployed in your tenant:</strong> CerbiShield and the scoring plane run inside your Azure tenant—no shared control planes.</li>
+                <li><strong>Vendor-agnostic:</strong> Governance sits before any sink or analytics vendor so you can keep or swap providers freely.</li>
+                <li><strong>No sink routing responsibility:</strong> Your collectors and pipelines keep forwarding logs; Cerbi never brokers or re-routes your traffic.</li>
+                <li><strong>Policies-as-code:</strong> Profiles are versioned, reviewed, and enforced through CI and runtime validators.</li>
+                <li><strong>Works with existing loggers:</strong> MEL, Serilog, NLog, and hybrid setups keep their formatters and sinks while Cerbi governs payloads.</li>
             </ul>
-
-            <h3 style="margin-top:28px;">Section 5: Disclaimers</h3>
-            <p class="muted">Pricing is provisional and intended for Marketplace previews; final terms, limits, and SLAs will be confirmed in order forms or private offers. Reporting exports support internal governance reviews and are not certified compliance artifacts. Cerbi governs schemas and tags/redacts payloads but leaves log routing within your stack.</p>
         </section>
+
+<section id="impact" class="impact-section">
+            <h2>Cost &amp; time impact in real teams</h2>
+            <p class="impact-note">
+                Illustrative pilot outcomes from governance-heavy rollouts—schema stability, redaction posture, and audit evidence drive the deltas. Your stack and rules will change the numbers.
+            </p>
+
+            <div class="impact-grid">
+                <article class="impact-card">
+                    <div class="impact-metric">40%</div>
+                    <h3>Less paid log volume</h3>
+                    <p>
+                        Cutting high-noise fields and junk events before they land reduces paid log volume by roughly 40% in pilots.
+                    </p>
+                </article>
+
+                <article class="impact-card">
+                    <div class="impact-metric">20–30%</div>
+                    <h3>Engineer time back</h3>
+                    <p>
+                        Guardrails keep schemas stable, so platform and SRE teams spend 20–30% less time chasing broken dashboards and queries.
+                    </p>
+                </article>
+
+                <article class="impact-card">
+                    <div class="impact-metric">Fewer cycles</div>
+                    <h3>Less audit &amp; compliance thrash</h3>
+                    <p>
+                        Versioned profiles and redaction history trim audit review cycles by replacing ad-hoc log dives with a clear paper trail.
+                    </p>
+                </article>
+            </div>
+
+            <div class="impact-breakdown">
+                <h3>What usually drives the savings</h3>
+
+                <div class="savings-bar" aria-hidden="true">
+                    <div class="segment segment-ingest" style="width:25%;">Less junk</div>
+                    <div class="segment segment-retention" style="width:15%;">Retention</div>
+                    <div class="segment segment-engineering" style="width:30%;">Eng time</div>
+                    <div class="segment segment-audit" style="width:30%;">Audit</div>
+                </div>
+
+                <div class="savings-grid">
+                    <div class="savings-item">
+                        <span class="percent">25%</span>
+                        <strong>Less junk ingested</strong>
+                        <p>Low-value fields and noisy events get dropped or normalized at the source (~25%).</p>
+                    </div>
+
+                    <div class="savings-item">
+                        <span class="percent">15%</span>
+                        <strong>Smarter retention with your routing</strong>
+                        <p>Noisy streams get shorter hot retention or move to cheaper storage using the pipelines you already own (~15%).</p>
+                    </div>
+
+                    <div class="savings-item">
+                        <span class="percent">30%</span>
+                        <strong>Engineering time back</strong>
+                        <p>Less time fixing queries and dashboards, more time fixing actual incidents (~30%).</p>
+                    </div>
+
+                    <div class="savings-item">
+                        <span class="percent">30%</span>
+                        <strong>Less audit thrash</strong>
+                        <p>Clear governance history instead of “dig through Kibana and hope” during reviews (~30%).</p>
+                    </div>
+                </div>
+            </div>
+
+            <p class="impact-disclaimer">
+                All figures are illustrative pilots, not guarantees. Cerbi gives you the controls; results depend on your services, volumes, and how rigorously you govern schemas, redaction posture, and audit evidence.
+            </p>
+        </section>
+
+<section id="quickstart" class="container section scroll-target">
+            <div class="eyebrow">How it works</div>
+            <h2 id="developers">Three steps to governed logging without rerouting traffic</h2>
+            <p class="lead">CerbiStream + CerbiShield provide tenant-hosted governance. You keep routing logs to any vendors or storage you choose.</p>
+
+            <div class="grid" style="--cols:3;gap:16px">
+                <article class="card" style="display:flex;flex-direction:column;gap:10px">
+                    <div class="chip">Step 1</div>
+                    <h3>Define governance profiles</h3>
+                    <p class="muted">Author required/forbidden/sensitive fields and redaction rules as JSON. Profiles live in your repos for review and promotion.</p>
+                </article>
+                <article class="card" style="display:flex;flex-direction:column;gap:10px">
+                    <div class="chip">Step 2</div>
+                    <h3>Enforce in CI + runtime</h3>
+                    <p class="muted">NuGet analyzers block schema drift in CI; runtime validators tag/redact violations without taking over your collectors or sinks.</p>
+                </article>
+                <article class="card" style="display:flex;flex-direction:column;gap:10px">
+                    <div class="chip">Step 3</div>
+                    <h3>Score and prove posture</h3>
+                    <p class="muted">CerbiShield tracks deployment history, RBAC, and governance scores so you can show improvements over time—while your log routing stays unchanged.</p>
+                </article>
+            </div>
+        </section>
+
+<section id="use-cases" class="container section scroll-target">
+            <div id="usecases" class="sr-only" aria-hidden="true"></div>
+            <div class="eyebrow">Real outcomes</div>
+            <h2><span class="hl">Use Cases</span> (for teams & execs)</h2>
+            <p class="lead">Short, concrete wins you can expect. Each can start small and expand safely across the org.</p>
+            <p class="muted" style="max-width:800px">Outcome examples are illustrative pilots grounded in governance controls, redaction posture, schema stability, and audit evidence; expect variance by stack.</p>
+
+            <div class="grid">
+                <article class="col-4 card">
+                    <h3>1. Cut Log Spend</h3>
+                    <p class="muted">Normalize fields, roll up noise, and de-duplicate before indexing.</p>
+                    <ul>
+                        <li>Govern logs at the source with versioned schemas and redaction before anything leaves the service</li>
+                        <li>Score governance outcomes release-over-release so you can prove controls are working</li>
+                    </ul>
+                </article>
+                <article class="col-4 card">
+                    <h3>2. Prove Compliance</h3>
+                    <p class="muted">Versioned PII policy + redaction metadata you can hand to Risk/Legal.</p>
+                    <ul>
+                        <li>Keep your logger and pipeline while policy rides along to any log destinations you choose</li>
+                        <li>RBAC & audit history in CerbiShield</li>
+                    </ul>
+                </article>
+                <article class="col-4 card">
+                    <h3>3. Stabilize Dashboards</h3>
+                    <p class="muted">Stop breaking charts every sprint due to field drift.</p>
+                    <ul>
+                        <li>Stable names & types</li>
+                        <li>Durable alerts across releases</li>
+                    </ul>
+                </article>
+                <article class="col-4 card">
+                    <h3>4. Accelerate Incidents</h3>
+                    <p class="muted">Consistent app/env/tenant/trace IDs → faster triage and MTTR.</p>
+                    <ul>
+                        <li>Joinable logs across services</li>
+                        <li>Violation context included</li>
+                    </ul>
+                </article>
+                <article class="col-4 card">
+                    <h3>5. Ship ML-Ready Telemetry</h3>
+                    <p class="muted">Clean, governed features for LLMs & models—without PII surprises.</p>
+                    <ul>
+                        <li>Tags, categories, enums</li>
+                        <li>Consistent shapes for training</li>
+                    </ul>
+                </article>
+                <article class="col-4 card">
+                    <h3>6. Adopt Gradually</h3>
+                    <p class="muted">Start with one domain, run in relax-mode, then tighten.</p>
+                    <ul>
+                        <li>Keep your loggers/log destinations</li>
+                        <li>No vendor lock-in</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+
+<section id="pricing" class="container section">
+            <div class="eyebrow">Licensing & Plans</div>
+            <div class="pricing-headline">
+                <div class="space-y-2">
+                    <h2>Pricing that tracks governed applications</h2>
+                    <p class="lead">Pricing is based on governed applications — not environments or traffic. One app across dev/test/uat/stage/prod counts as one license.</p>
+                    <p class="muted">CerbiStream + CerbiShield provide tenant-hosted structured logging governance. Cerbi does not route logs to vendors; you keep your collectors and destinations.</p>
+                </div>
+                <div class="pricing-badges">
+                    <span class="pill">Environments don’t count separately.</span>
+                    <span class="pill">One app = dev/test/uat/stage/prod.</span>
+                </div>
+            </div>
+
+            <p class="app-note"><strong>What counts as an app?</strong> A single governed application or service, even if it spans dev/test/uat/stage/prod. When microservices are governed separately, they count individually.</p>
+
+            <div class="pricing-grid">
+                <article class="pricing-card">
+                    <div class="pricing-meta">
+                        <h3>Free</h3>
+                        <span class="pricing-limit">1 app</span>
+                    </div>
+                    <div class="pricing-price">$0</div>
+                    <p class="muted">Validate CerbiStream locally with baseline governance and redaction patterns.</p>
+                    <ul>
+                        <li>MIT-licensed analyzers + runtime guards</li>
+                        <li>Governance profiles stored in your repo</li>
+                        <li>Local audit history for change awareness</li>
+                        <li>Works with your existing logging and routing</li>
+                    </ul>
+                </article>
+
+                <article class="pricing-card">
+                    <div class="pricing-meta">
+                        <h3>Basic</h3>
+                        <span class="pricing-limit">5 apps</span>
+                    </div>
+                    <div class="pricing-price">$99/mo</div>
+                    <p class="muted">Add lightweight RBAC and CI enforcement for small teams.</p>
+                    <ul>
+                        <li>Analyzer enforcement to block schema drift</li>
+                        <li>Email or SSO access with audit logs</li>
+                        <li>Deployment targets for test + prod parity</li>
+                        <li>JSON import/export for governance-as-code</li>
+                    </ul>
+                </article>
+
+                <article class="pricing-card pricing-most-popular">
+                    <div class="pricing-meta">
+                        <h3>Pro</h3>
+                        <span class="pricing-limit">20 apps</span>
+                    </div>
+                    <div class="pricing-price">$299/mo</div>
+                    <p class="muted">Most popular for platform teams standardizing schemas with traceable history.</p>
+                    <ul>
+                        <li>Runtime enforcement + redaction to cut noisy payloads</li>
+                        <li>RBAC depth with SSO/SCIM and approval flows</li>
+                        <li>Versioned governance profiles with deployment history</li>
+                        <li>Scoring API visibility for leadership rollups</li>
+                    </ul>
+                </article>
+
+                <article class="pricing-card">
+                    <div class="pricing-meta">
+                        <h3>Pro++</h3>
+                        <span class="pricing-limit">50 apps</span>
+                    </div>
+                    <div class="pricing-price">$599/mo</div>
+                    <p class="muted">For large estates needing governed reporting and broader app coverage.</p>
+                    <ul>
+                        <li>Hierarchical RBAC and SCIM provisioning</li>
+                        <li>Governed reporting exports for internal reviews</li>
+                        <li>Regional deployment targets with rollback metadata</li>
+                        <li>Priority support and private offer options</li>
+                    </ul>
+                </article>
+            </div>
+
+            <div class="pricing-compare">
+                <div class="compare-grid compare-header">
+                    <div></div>
+                    <div class="compare-tier">Free</div>
+                    <div class="compare-tier">Basic</div>
+                    <div class="compare-tier">Pro</div>
+                    <div class="compare-tier">Pro++</div>
+                </div>
+                <div class="compare-grid compare-row">
+                    <div class="compare-label">Governance profiles</div>
+                    <div class="compare-cell">✔︎</div>
+                    <div class="compare-cell">✔︎</div>
+                    <div class="compare-cell">✔︎</div>
+                    <div class="compare-cell">✔︎</div>
+                </div>
+                <div class="compare-grid compare-row">
+                    <div class="compare-label">CI analyzers</div>
+                    <div class="compare-cell">✔︎</div>
+                    <div class="compare-cell">✔︎</div>
+                    <div class="compare-cell">✔︎</div>
+                    <div class="compare-cell">✔︎</div>
+                </div>
+                <div class="compare-grid compare-row">
+                    <div class="compare-label">Runtime enforcement</div>
+                    <div class="compare-cell">Core</div>
+                    <div class="compare-cell">Standard</div>
+                    <div class="compare-cell">Advanced</div>
+                    <div class="compare-cell">Advanced</div>
+                </div>
+                <div class="compare-grid compare-row">
+                    <div class="compare-label">Scoring posture</div>
+                    <div class="compare-cell muted">Preview</div>
+                    <div class="compare-cell">Included</div>
+                    <div class="compare-cell">Full</div>
+                    <div class="compare-cell">Full</div>
+                </div>
+                <div class="compare-grid compare-row">
+                    <div class="compare-label">Deployment history</div>
+                    <div class="compare-cell muted">Local</div>
+                    <div class="compare-cell">Standard</div>
+                    <div class="compare-cell">Versioned</div>
+                    <div class="compare-cell">Versioned</div>
+                </div>
+                <div class="compare-grid compare-row">
+                    <div class="compare-label">RBAC</div>
+                    <div class="compare-cell muted">Basic</div>
+                    <div class="compare-cell">Team</div>
+                    <div class="compare-cell">Enterprise</div>
+                    <div class="compare-cell">Enterprise</div>
+                </div>
+            </div>
+
+            <p class="muted" style="margin-top:16px;">Pricing is provisional for Marketplace previews; final terms, limits, and SLAs will be confirmed in order forms or private offers. Cerbi governs schemas and redacts/tag payloads but leaves log routing entirely under your control.</p>
+        </section>
+
+
+<section id="faq" class="container section">
+            <div class="eyebrow">Common Questions</div>
+            <h2>Frequently Asked <span class="hl">Questions</span></h2>
+            <p class="lead" style="text-align:center;max-width:700px;margin:0 auto 3rem">
+                Get quick answers to common questions about CerbiSuite. Still have questions? Contact us below.
+            </p>
+
+            <div class="faq-grid">
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>Is this just another logger?</h3>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>No. CerbiStream is a governance-first logger. While traditional loggers focus on capturing data, CerbiStream adds built-in governance, compliance validation, PII redaction, and ML-ready structured output. Think of it as a logger + compliance engine + data quality platform in one.</p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>How hard is migration from Serilog or NLog?</h3>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>
+                            CerbiStream uses familiar .NET logging abstractions and can run alongside Serilog, NLog, or MEL during rollout. You can enable Cerbi for a subset of services first, validate governance profiles, and then expand as you gain confidence. Many teams can prototype integration in a day or less, but full cut-over timing depends on your codebase and the governance rules you choose to enforce.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>Where is my data stored? Do you have access to it?</h3>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>
+                            CerbiStream writes logs to destinations you configure (files, databases, queues, SIEMs) inside your environment. We don’t operate a centralized log-ingestion SaaS, and we don’t have access to your application log payloads. Optional analytics features can work on derived governance metadata if you explicitly enable them, but raw logs remain under your control.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>What about performance? Will this slow down my application?</h3>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>
+                            CerbiStream is designed to stay off the hot path. Logging uses async Channel-based buffering so
+                            application threads aren’t blocked, and governance validation runs in the background. In our
+                            BenchmarkDotNet tests on typical .NET workloads, CerbiStream’s overhead was comparable to
+                            established .NET loggers. Exact numbers depend on your payloads, sinks, and governance rules.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>What .NET versions does CerbiStream support?</h3>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>CerbiStream targets .NET 8 and .NET 9 on NuGet, with computed compatibility forward to .NET 10+. Older services on .NET 6 or .NET 7, as well as legacy .NET Framework apps, can integrate through the Microsoft.Extensions.Logging abstractions or adapter patterns, but first-class support and testing focus on the current runtimes.</p>
+                    </div>
+                </div>
+
+                    <div class="faq-item">
+                        <div class="faq-question">
+                            <h3>Is CerbiSuite open source? What's the licensing model?</h3>
+                            <span class="faq-icon">+</span>
+                        </div>
+                        <div class="faq-answer">
+                            <p>
+                                CerbiStream core and the shared governance libraries (for example, Cerbi.Governance.Core and
+                                Cerbi.Governance.Runtime) are open source under the MIT license. CerbiShield (the governance
+                                dashboard, APIs, reporting, and scoring) is licensed commercially <strong>per governed
+                                application</strong>—not per environment—and includes support and SLAs. Check each repo or
+                                NuGet page for the exact license; runtime pieces are permissive, governance/dashboard/scoring
+                                are paid.
+                            </p>
+                        </div>
+                    </div>
+
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>What makes CerbiSuite different from Datadog or ELK?</h3>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>Datadog and ELK are observability platforms that consume logs. CerbiSuite focuses on log creation and governance at the source. Use CerbiStream to create high-quality, compliant logs, then send them to Datadog, ELK, or any other platform. We complement observability tools; we don't replace them.</p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>Can I try it before committing? Is there a demo environment?</h3>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>Absolutely! Use our <a href="#quickstart">60-second Quick Start</a> to install CerbiStream via NuGet and try it locally. For enterprise features, <a href="#contact">request a demo</a> and we'll set up a sandbox environment with your data. No commitment required.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+
+
+
+
+
+
+
+
+
+
+
+        
 
         <section class="container section capabilities" aria-label="Capabilities">
             <div class="capabilities-head">
@@ -1761,64 +2035,7 @@
             <div class="card video-card-shell" data-video-card="brief-overview"></div>
         </section>
 
-        <section id="use-cases" class="container section scroll-target">
-            <div id="usecases" class="sr-only" aria-hidden="true"></div>
-            <div class="eyebrow">Real outcomes</div>
-            <h2><span class="hl">Use Cases</span> (for teams & execs)</h2>
-            <p class="lead">Short, concrete wins you can expect. Each can start small and expand safely across the org.</p>
-            <p class="muted" style="max-width:800px">Outcome examples are illustrative pilots grounded in governance controls, redaction posture, schema stability, and audit evidence; expect variance by stack.</p>
-
-            <div class="grid">
-                <article class="col-4 card">
-                    <h3>1. Cut Log Spend</h3>
-                    <p class="muted">Normalize fields, roll up noise, and de-duplicate before indexing.</p>
-                    <ul>
-                        <li>Govern logs at the source with versioned schemas and redaction before anything leaves the service</li>
-                        <li>Score governance outcomes release-over-release so you can prove controls are working</li>
-                    </ul>
-                </article>
-                <article class="col-4 card">
-                    <h3>2. Prove Compliance</h3>
-                    <p class="muted">Versioned PII policy + redaction metadata you can hand to Risk/Legal.</p>
-                    <ul>
-                        <li>Keep your logger and pipeline while policy rides along to any log destinations you choose</li>
-                        <li>RBAC & audit history in CerbiShield</li>
-                    </ul>
-                </article>
-                <article class="col-4 card">
-                    <h3>3. Stabilize Dashboards</h3>
-                    <p class="muted">Stop breaking charts every sprint due to field drift.</p>
-                    <ul>
-                        <li>Stable names & types</li>
-                        <li>Durable alerts across releases</li>
-                    </ul>
-                </article>
-                <article class="col-4 card">
-                    <h3>4. Accelerate Incidents</h3>
-                    <p class="muted">Consistent app/env/tenant/trace IDs → faster triage and MTTR.</p>
-                    <ul>
-                        <li>Joinable logs across services</li>
-                        <li>Violation context included</li>
-                    </ul>
-                </article>
-                <article class="col-4 card">
-                    <h3>5. Ship ML-Ready Telemetry</h3>
-                    <p class="muted">Clean, governed features for LLMs & models—without PII surprises.</p>
-                    <ul>
-                        <li>Tags, categories, enums</li>
-                        <li>Consistent shapes for training</li>
-                    </ul>
-                </article>
-                <article class="col-4 card">
-                    <h3>6. Adopt Gradually</h3>
-                    <p class="muted">Start with one domain, run in relax-mode, then tighten.</p>
-                    <ul>
-                        <li>Keep your loggers/log destinations</li>
-                        <li>No vendor lock-in</li>
-                    </ul>
-                </article>
-            </div>
-        </section>
+        
 
         <!-- Security & Compliance Section -->
         <section id="security" class="container section scroll-target" style="background:linear-gradient(135deg, rgba(255,77,0,.08) 0%, rgba(20,40,72,.06) 100%);color:var(--text-strong);border-radius:20px;padding-inline:48px;border:1px solid rgba(20,40,72,.08);box-shadow:0 22px 60px rgba(20,40,72,.08)">
@@ -1934,34 +2151,7 @@
         </section>
 
         <div id="quick-start" class="sr-only" aria-hidden="true"></div>
-        <section id="quickstart" class="container section scroll-target">
-            <div class="eyebrow">Get started</div>
-            <h2 id="developers">⚡ <span class="hl">Quick Start</span>: Try <span class="hl">CerbiStream</span> in 60 Seconds</h2>
-            <p class="lead">Install from NuGet, configure in <code>Program.cs</code>, and log safely with governance validation.</p>
-
-            <div class="card" style="padding:18px;position:relative">
-<pre class="kbd" style="white-space:pre-wrap"><code>// 1) Install
-dotnet add package CerbiStream
-dotnet add package Cerbi.MEL.Governance
-dotnet add package CerbiStream.GovernanceAnalyzer
-
-// 2) Configure in Program.cs (MEL)
-using CerbiStream;
-var logger = LoggerFactory.Create(builder =>
-{
-  builder.AddCerbiStream(options =>
-  {
-    options.WithFileFallback();
-    options.UseGovernance("cerbi_governance.json");
-  });
-}).CreateLogger&lt;Program&gt;();
-
-// 3) Log safely with governance validation
-logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
-</code></pre>
-                <button class="btn btn-ghost" data-copy="#quickstart code" style="position:absolute;top:12px;right:12px">Copy</button>
-            </div>
-        </section>
+        
 
         <section id="ecosystem" class="container section">
             <div class="eyebrow">What's included</div>
@@ -2151,79 +2341,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             </div>
         </section>
 
-        <section id="impact" class="impact-section">
-            <h2>Cost &amp; time impact in real teams</h2>
-            <p class="impact-note">
-                Illustrative pilot outcomes from governance-heavy rollouts—schema stability, redaction posture, and audit evidence drive the deltas. Your stack and rules will change the numbers.
-            </p>
-
-            <div class="impact-grid">
-                <article class="impact-card">
-                    <div class="impact-metric">40%</div>
-                    <h3>Less paid log volume</h3>
-                    <p>
-                        Cutting high-noise fields and junk events before they land reduces paid log volume by roughly 40% in pilots.
-                    </p>
-                </article>
-
-                <article class="impact-card">
-                    <div class="impact-metric">20–30%</div>
-                    <h3>Engineer time back</h3>
-                    <p>
-                        Guardrails keep schemas stable, so platform and SRE teams spend 20–30% less time chasing broken dashboards and queries.
-                    </p>
-                </article>
-
-                <article class="impact-card">
-                    <div class="impact-metric">Fewer cycles</div>
-                    <h3>Less audit &amp; compliance thrash</h3>
-                    <p>
-                        Versioned profiles and redaction history trim audit review cycles by replacing ad-hoc log dives with a clear paper trail.
-                    </p>
-                </article>
-            </div>
-
-            <div class="impact-breakdown">
-                <h3>What usually drives the savings</h3>
-
-                <div class="savings-bar" aria-hidden="true">
-                    <div class="segment segment-ingest" style="width:25%;">Less junk</div>
-                    <div class="segment segment-retention" style="width:15%;">Retention</div>
-                    <div class="segment segment-engineering" style="width:30%;">Eng time</div>
-                    <div class="segment segment-audit" style="width:30%;">Audit</div>
-                </div>
-
-                <div class="savings-grid">
-                    <div class="savings-item">
-                        <span class="percent">25%</span>
-                        <strong>Less junk ingested</strong>
-                        <p>Low-value fields and noisy events get dropped or normalized at the source (~25%).</p>
-                    </div>
-
-                    <div class="savings-item">
-                        <span class="percent">15%</span>
-                        <strong>Smarter retention with your routing</strong>
-                        <p>Noisy streams get shorter hot retention or move to cheaper storage using the pipelines you already own (~15%).</p>
-                    </div>
-
-                    <div class="savings-item">
-                        <span class="percent">30%</span>
-                        <strong>Engineering time back</strong>
-                        <p>Less time fixing queries and dashboards, more time fixing actual incidents (~30%).</p>
-                    </div>
-
-                    <div class="savings-item">
-                        <span class="percent">30%</span>
-                        <strong>Less audit thrash</strong>
-                        <p>Clear governance history instead of “dig through Kibana and hope” during reviews (~30%).</p>
-                    </div>
-                </div>
-            </div>
-
-            <p class="impact-disclaimer">
-                All figures are illustrative pilots, not guarantees. Cerbi gives you the controls; results depend on your services, volumes, and how rigorously you govern schemas, redaction posture, and audit evidence.
-            </p>
-        </section>
+        
 
         <section id="architecture" class="container section">
             <div class="eyebrow">How it fits</div>
@@ -2255,18 +2373,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             </div>
         </section>
 
-        <section id="trust" class="container section panel-section">
-            <div class="eyebrow">Trust</div>
-            <h2>Control and confidence <span class="hl">by design</span></h2>
-            <p class="muted" style="max-width:820px;margin:0 auto 24px">Deployment, governance, and routing stay under your control. Cerbi enforces policy without taking over your log transport or locking you into a vendor path.</p>
-            <ul class="checked-list" style="grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px 18px">
-                <li><strong>Deployed in your tenant:</strong> CerbiShield and the scoring plane run inside your Azure tenant—no shared control planes.</li>
-                <li><strong>Vendor-agnostic:</strong> Governance sits before any sink or analytics vendor so you can keep or swap providers freely.</li>
-                <li><strong>No sink routing responsibility:</strong> Your collectors and pipelines keep forwarding logs; Cerbi never brokers or re-routes your traffic.</li>
-                <li><strong>Policies-as-code:</strong> Profiles are versioned, reviewed, and enforced through CI and runtime validators.</li>
-                <li><strong>Works with existing loggers:</strong> MEL, Serilog, NLog, and hybrid setups keep their formatters and sinks while Cerbi governs payloads.</li>
-            </ul>
-        </section>
+        
 
         <section id="adoption-safety" class="container section panel-section">
             <div class="eyebrow">Adoption safety</div>
@@ -3872,111 +3979,7 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
         </section>
 
         <!-- FAQ Section -->
-        <section id="faq" class="container section">
-            <div class="eyebrow">Common Questions</div>
-            <h2>Frequently Asked <span class="hl">Questions</span></h2>
-            <p class="lead" style="text-align:center;max-width:700px;margin:0 auto 3rem">
-                Get quick answers to common questions about CerbiSuite. Still have questions? Contact us below.
-            </p>
-
-            <div class="faq-grid">
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Is this just another logger?</h3>
-                        <span class="faq-icon">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>No. CerbiStream is a governance-first logger. While traditional loggers focus on capturing data, CerbiStream adds built-in governance, compliance validation, PII redaction, and ML-ready structured output. Think of it as a logger + compliance engine + data quality platform in one.</p>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>How hard is migration from Serilog or NLog?</h3>
-                        <span class="faq-icon">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>
-                            CerbiStream uses familiar .NET logging abstractions and can run alongside Serilog, NLog, or MEL during rollout. You can enable Cerbi for a subset of services first, validate governance profiles, and then expand as you gain confidence. Many teams can prototype integration in a day or less, but full cut-over timing depends on your codebase and the governance rules you choose to enforce.
-                        </p>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Where is my data stored? Do you have access to it?</h3>
-                        <span class="faq-icon">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>
-                            CerbiStream writes logs to destinations you configure (files, databases, queues, SIEMs) inside your environment. We don’t operate a centralized log-ingestion SaaS, and we don’t have access to your application log payloads. Optional analytics features can work on derived governance metadata if you explicitly enable them, but raw logs remain under your control.
-                        </p>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>What about performance? Will this slow down my application?</h3>
-                        <span class="faq-icon">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>
-                            CerbiStream is designed to stay off the hot path. Logging uses async Channel-based buffering so
-                            application threads aren’t blocked, and governance validation runs in the background. In our
-                            BenchmarkDotNet tests on typical .NET workloads, CerbiStream’s overhead was comparable to
-                            established .NET loggers. Exact numbers depend on your payloads, sinks, and governance rules.
-                        </p>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>What .NET versions does CerbiStream support?</h3>
-                        <span class="faq-icon">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>CerbiStream targets .NET 8 and .NET 9 on NuGet, with computed compatibility forward to .NET 10+. Older services on .NET 6 or .NET 7, as well as legacy .NET Framework apps, can integrate through the Microsoft.Extensions.Logging abstractions or adapter patterns, but first-class support and testing focus on the current runtimes.</p>
-                    </div>
-                </div>
-
-                    <div class="faq-item">
-                        <div class="faq-question">
-                            <h3>Is CerbiSuite open source? What's the licensing model?</h3>
-                            <span class="faq-icon">+</span>
-                        </div>
-                        <div class="faq-answer">
-                            <p>
-                                CerbiStream core and the shared governance libraries (for example, Cerbi.Governance.Core and
-                                Cerbi.Governance.Runtime) are open source under the MIT license. CerbiShield (the governance
-                                dashboard, APIs, reporting, and scoring) is licensed commercially <strong>per governed
-                                application</strong>—not per environment—and includes support and SLAs. Check each repo or
-                                NuGet page for the exact license; runtime pieces are permissive, governance/dashboard/scoring
-                                are paid.
-                            </p>
-                        </div>
-                    </div>
-
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>What makes CerbiSuite different from Datadog or ELK?</h3>
-                        <span class="faq-icon">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Datadog and ELK are observability platforms that consume logs. CerbiSuite focuses on log creation and governance at the source. Use CerbiStream to create high-quality, compliant logs, then send them to Datadog, ELK, or any other platform. We complement observability tools; we don't replace them.</p>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Can I try it before committing? Is there a demo environment?</h3>
-                        <span class="faq-icon">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Absolutely! Use our <a href="#quickstart">60-second Quick Start</a> to install CerbiStream via NuGet and try it locally. For enterprise features, <a href="#contact">request a demo</a> and we'll set up a sandbox environment with your data. No commitment required.</p>
-                    </div>
-                </div>
-            </div>
-        </section>
+        
 
         <section id="contact" class="container section">
             <div class="eyebrow">Let's talk</div>


### PR DESCRIPTION
## Summary
- reorder the primary homepage flow to highlight trust, outcomes, how Cerbi works, use cases, and refreshed pricing before FAQ
- redesign the pricing section with responsive four-tier grid, governed-app messaging, and a comparison row while emphasizing that Cerbi never routes logs
- tune spacing utilities and add concise copy to reduce clutter and clarify that pricing is based on governed applications

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ce1094d0832daed3adf59356959b)