### PR TITLE
Rename CerbiShield Enterprise tier to CerbiShield Pro++

### DIFF
--- a/index.html
+++ b/index.html
@@ -1700,7 +1700,7 @@
 
                 <article class="pricing-card">
                     <div class="pricing-meta">
-                        <h3>CerbiShield Enterprise</h3>
+                        <h3>CerbiShield Pro++</h3>
                         <span class="pricing-limit">Up to 100 governed apps • Unlimited deployment targets</span>
                     </div>
                     <div class="pricing-price">$499 / month</div>
@@ -1721,7 +1721,7 @@
                     <div></div>
                     <div class="compare-tier">CerbiShield Basic</div>
                     <div class="compare-tier">CerbiShield Pro</div>
-                    <div class="compare-tier">CerbiShield Enterprise</div>
+                    <div class="compare-tier">CerbiShield Pro++</div>
                 </div>
                 <div class="compare-grid compare-row">
                     <div class="compare-label">Governed apps included</div>


### PR DESCRIPTION
## Summary
- update the pricing card heading to call the top tier CerbiShield Pro++
- align the comparison table label with the new CerbiShield Pro++ name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af47352b0832d9f8666454904a519)

## Summary by Sourcery

Rename the top CerbiShield pricing tier from Enterprise to Pro++ across the marketing page.

Enhancements:
- Update the top-tier pricing card heading to use the CerbiShield Pro++ name.
- Align the pricing comparison table tier label with the CerbiShield Pro++ branding.