### PR TITLE
Update CerbiShield pricing and comparison details

### DIFF
--- a/index.html
+++ b/index.html
@@ -1690,10 +1690,9 @@
                     <p class="muted">For platform and SRE teams standardizing governance.</p>
                     <ul>
                         <li>Everything in Basic</li>
-                        <li>SSO/SAML integration</li>
+                        <li>SSO integration (e.g., Azure AD / OIDC)</li>
                         <li>Team-based RBAC (admin/owner/editor/read-only)</li>
                         <li>Reporting & export (CSV/JSON + basic PDFs)</li>
-                        <li>Notifications (email / Slack / webhook)</li>
                         <li>Priority email support</li>
                     </ul>
                 </article>
@@ -1701,17 +1700,17 @@
                 <article class="pricing-card">
                     <div class="pricing-meta">
                         <h3>CerbiShield Pro++</h3>
-                        <span class="pricing-limit">Up to 100 governed apps • Unlimited deployment targets</span>
+                        <span class="pricing-limit">Unlimited governed apps • Unlimited deployment targets</span>
                     </div>
                     <div class="pricing-price">$499 / month</div>
-                    <p class="muted">For regulated and large estates.</p>
+                    <p class="muted">For regulated and large estates that need full visibility.</p>
                     <ul>
                         <li>Everything in Pro</li>
                         <li>Org-wide governance rollups across apps</li>
                         <li>Advanced reporting packs and dashboards</li>
                         <li>API access for reporting and integrations</li>
                         <li>Higher-touch onboarding & support</li>
-                        <li>Need more than 100 apps? Custom pricing via private offer.</li>
+                        <li>Need special terms? Custom pricing via private offer.</li>
                     </ul>
                 </article>
             </div>
@@ -1727,12 +1726,12 @@
                     <div class="compare-label">Governed apps included</div>
                     <div class="compare-cell">Up to 10</div>
                     <div class="compare-cell">Up to 30</div>
-                    <div class="compare-cell">Up to 100 (custom beyond)</div>
+                    <div class="compare-cell">Unlimited</div>
                 </div>
                 <div class="compare-grid compare-row">
                     <div class="compare-label">Deployment targets</div>
                     <div class="compare-cell">1</div>
-                    <div class="compare-cell">Up to 3</div>
+                    <div class="compare-cell">3</div>
                     <div class="compare-cell">Unlimited</div>
                 </div>
                 <div class="compare-grid compare-row">
@@ -1760,7 +1759,7 @@
                     <div class="compare-cell">Enterprise</div>
                 </div>
                 <div class="compare-grid compare-row">
-                    <div class="compare-label">SSO/SAML</div>
+                    <div class="compare-label">SSO</div>
                     <div class="compare-cell muted">—</div>
                     <div class="compare-cell">Included</div>
                     <div class="compare-cell">Included</div>
@@ -1770,12 +1769,6 @@
                     <div class="compare-cell muted">—</div>
                     <div class="compare-cell">CSV/JSON + basic PDFs</div>
                     <div class="compare-cell">Advanced packs</div>
-                </div>
-                <div class="compare-grid compare-row">
-                    <div class="compare-label">Notifications (email/Slack/webhook)</div>
-                    <div class="compare-cell muted">—</div>
-                    <div class="compare-cell">Included</div>
-                    <div class="compare-cell">Included</div>
                 </div>
                 <div class="compare-grid compare-row">
                     <div class="compare-label">API access for reporting & data integration</div>


### PR DESCRIPTION
## Summary
- Align pricing cards for CerbiShield Basic, Pro, and Pro++ with updated allowances, messaging, and support notes
- Update the plan comparison table to reflect the new limits and capabilities, removing notifications and deprecated values
- Clarify Pro++ unlimited scope and custom offer language consistent with current product terms

## Testing
- Not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af8b32f38832d89ef0417ba38db37)

## Summary by Sourcery

Update CerbiShield Pro and Pro++ marketing content and comparison details to reflect current plan limits and capabilities.

Enhancements:
- Clarify SSO capabilities and naming across the Pro pricing card and comparison table.
- Adjust Pro++ governed app limits and description to indicate unlimited coverage and refined targeting of large regulated estates.
- Simplify deployment target limits and language for Pro and Pro++ plans in the comparison table.
- Remove notifications as a listed capability from pricing and comparison content to match the current product offering.
- Refresh Pro++ custom pricing language to cover broader special-term scenarios.