### PR TITLE
Update CerbiShield pricing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1700,7 +1700,7 @@
                 <article class="pricing-card">
                     <div class="pricing-meta">
                         <h3>CerbiShield Pro++</h3>
-                        <span class="pricing-limit">Unlimited governed apps • Unlimited deployment targets</span>
+                        <span class="pricing-limit">Up to 100 governed apps • Unlimited deployment targets</span>
                     </div>
                     <div class="pricing-price">$499 / month</div>
                     <p class="muted">For regulated and large estates that need full visibility.</p>
@@ -1715,6 +1715,10 @@
                 </article>
             </div>
 
+            <p class="muted" style="margin-top:16px;">
+                Need to cover more than 100 governed apps or have special compliance requirements? We offer Custom Enterprise plans with tailored pricing and terms.
+            </p>
+
             <div class="pricing-compare">
                 <div class="compare-grid compare-header">
                     <div></div>
@@ -1726,7 +1730,7 @@
                     <div class="compare-label">Governed apps included</div>
                     <div class="compare-cell">Up to 10</div>
                     <div class="compare-cell">Up to 30</div>
-                    <div class="compare-cell">Unlimited</div>
+                    <div class="compare-cell">Up to 100</div>
                 </div>
                 <div class="compare-grid compare-row">
                     <div class="compare-label">Deployment targets</div>


### PR DESCRIPTION
## Summary
- cap CerbiShield Pro++ at 100 governed apps and update comparison table accordingly
- add enterprise availability note below the pricing plans

## Testing
- not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b37975594832d97ddb87ee7de7a54)

## Summary by Sourcery

Update CerbiShield Pro++ pricing limits and clarify enterprise availability in the pricing section.

New Features:
- Add a note about Custom Enterprise plans for customers needing more than 100 governed apps or special compliance terms.

Enhancements:
- Cap CerbiShield Pro++ at 100 governed apps in both the plan description and comparison table to better reflect the intended pricing tiers.