### PR TITLE
Add Cerbi overview PDF link to hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1576,6 +1576,9 @@
                         <a href="#contact" class="btn btn-secondary btn-large">
                             Request Pilot Access
                         </a>
+                        <a href="docs/Shift_Left_Log_Governance.pdf" class="btn btn-ghost btn-large" target="_blank" rel="noopener">
+                            Download Cerbi Overview (PDF)
+                        </a>
                     </div>
 
                     <div class="hero-banner">


### PR DESCRIPTION
## Summary
- add a hero call-to-action linking to the Cerbi overview PDF deck

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445087b6b8832d9affca8728a44f1e)

## Summary by Sourcery

New Features:
- Expose a downloadable Cerbi overview PDF from the hero section via a new call-to-action button.