### PR TITLE
Improve contact form fallback for static hosting

### DIFF
--- a/index-draft.html
+++ b/index-draft.html
@@ -2097,22 +2097,31 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
             const status = document.getElementById('contactStatus');
             const btn = document.getElementById('contactSubmit');
 
+            const sendNative = () => {
+                form.removeEventListener('submit', submitAjax);
+                form.submit();
+            };
+
             async function submitAjax(e) {
                 e.preventDefault();
-                status.textContent = '';
+                status.textContent = 'Sending…';
                 btn.disabled = true;
 
                 // simple client-side validity check
                 if (!form.reportValidity()) {
+                    status.textContent = '';
                     btn.disabled = false;
                     return;
                 }
 
+                const payload = new FormData(form);
+
                 try {
                     const res = await fetch(form.action, {
-                        method: 'POST',
+                        method: form.method || 'POST',
+                        mode: 'cors',
                         headers: { 'Accept': 'application/json' },
-                        body: new FormData(form)
+                        body: payload
                     });
 
                     if (res.ok) {
@@ -2123,10 +2132,17 @@ logger.LogInformation("User logged in {@user}", new { UserId = "12345" });
                         // Optional: swap the form for a thank-you block
                         // form.outerHTML = '<div class="muted">Thanks — we’ll be in touch shortly.</div>';
                     } else {
-                        status.textContent = "Sorry, something went wrong. Please email hello@cerbi.io.";
+                        try {
+                            const error = await res.json();
+                            const message = Array.isArray(error?.errors) ? error.errors.map(e => e.message).join(' ') : '';
+                            status.textContent = message || "Sorry, something went wrong. Please email hello@cerbi.io.";
+                        } catch {
+                            status.textContent = "Sorry, something went wrong. Please email hello@cerbi.io.";
+                        }
                     }
                 } catch {
-                    status.textContent = "Network error. Please try again or email hello@cerbi.io.";
+                    status.textContent = "Network error. Submitting via backup…";
+                    sendNative();
                 } finally {
                     btn.disabled = false;
                 }

--- a/index.html
+++ b/index.html
@@ -4446,21 +4446,30 @@
             const status = document.getElementById('contactStatus');
             const btn = document.getElementById('contactSubmit');
 
+            const sendNative = () => {
+                form.removeEventListener('submit', submitAjax);
+                form.submit();
+            };
+
             async function submitAjax(e) {
                 e.preventDefault();
-                status.textContent = '';
+                status.textContent = 'Sending…';
                 btn.disabled = true;
 
                 if (!form.reportValidity()) {
+                    status.textContent = '';
                     btn.disabled = false;
                     return;
                 }
 
+                const payload = new FormData(form);
+
                 try {
                     const res = await fetch(form.action, {
-                        method: 'POST',
+                        method: form.method || 'POST',
+                        mode: 'cors',
                         headers: { 'Accept': 'application/json' },
-                        body: new FormData(form)
+                        body: payload
                     });
 
                     if (res.ok) {
@@ -4468,10 +4477,18 @@
                         form.reset();
                         status.textContent = "Thanks — we'll be in touch shortly.";
                     } else {
-                        status.textContent = "Sorry, something went wrong. Please email hello@cerbi.io.";
+                        try {
+                            const error = await res.json();
+                            const message = Array.isArray(error?.errors) ? error.errors.map(e => e.message).join(' ') : '';
+                            status.textContent = message || "Sorry, something went wrong. Please email hello@cerbi.io.";
+                        } catch {
+                            status.textContent = "Sorry, something went wrong. Please email hello@cerbi.io.";
+                        }
                     }
                 } catch {
-                    status.textContent = "Network error. Please try again or email hello@cerbi.io.";
+                    // If network or CORS fails, fall back to the native form submission
+                    status.textContent = "Network error. Submitting via backup…";
+                    sendNative();
                 } finally {
                     btn.disabled = false;
                 }


### PR DESCRIPTION
## Summary
- add a native-submit fallback helper so the contact form can recover cleanly from fetch/CORS issues on static hosts
- mirror the contact form fallback refinement on the draft page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c8b6d488c832dbe5885305a8e7287)

## Summary by Sourcery

Improve the contact form’s resilience by adding a native submission fallback when AJAX requests fail and aligning the draft page’s contact form behavior with the main site.

Bug Fixes:
- Ensure contact form submissions still succeed via native form POST when fetch or CORS errors occur on static hosts.

Enhancements:
- Provide clearer in-flight and error status messaging for contact form submissions, including parsing structured error responses from the backend.
- Reuse the form’s configured HTTP method in AJAX requests instead of always forcing POST.
- Keep the draft contact page’s contact form logic in sync with the main contact form behavior.