### PR TITLE
Add governance demo API to ecosystem

### DIFF
--- a/index.html
+++ b/index.html
@@ -2888,6 +2888,17 @@
                                 <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Runtime validator + score shipper.</p>
                             </button>
 
+                            <button type="button" class="repo-node" data-repo="demo-api">
+                                <div class="repo-icon">🧪</div>
+                                <h4 class="repo-name">CerbiStream.Governance.Demo.API</h4>
+                                <p class="repo-tagline">Minimal API wiring CerbiStream logging with runtime governance validation and Swagger.</p>
+                                <div class="repo-status">
+                                    <span class="badge badge-beta">Demo</span>
+                                    <span class="badge badge-api">API</span>
+                                </div>
+                                <p class="muted" style="font-size:12px;margin:6px 0 0;">Role: Hands-on demo for governed logging + request validation.</p>
+                            </button>
+
                             <button type="button" class="repo-node" data-repo="serilog">
                                 <div class="repo-icon">📊</div>
                                 <h4 class="repo-name">Cerbi.Serilog.GovernanceAnalyzer</h4>
@@ -3831,6 +3842,7 @@
             .badge-web { background: #f0e8ff; color: #4d1b99; }
             .badge-serilog { background: #fff0e8; color: #994d1b; }
             .badge-lib { background: #f5f5f5; color: #666; }
+            .badge-api { background: #e6f7ff; color: #0b63a5; }
 
             /* Detail panel */
             .repo-detail-panel {
@@ -5385,6 +5397,14 @@
                     tagline: 'Runtime adapter for Microsoft.Extensions.Logging pipelines.'
                 },
                 {
+                    key: 'demo-api',
+                    name: 'CerbiStream.Governance.Demo.API',
+                    status: 'Demo',
+                    tags: [{ class: 'api', label: 'API' }],
+                    role: 'Minimal API showing CerbiStream logging with runtime governance validation.',
+                    tagline: 'Hands-on demo for governed logging + request validation.'
+                },
+                {
                     key: 'serilog',
                     name: 'Cerbi.Serilog.GovernanceAnalyzer',
                     status: 'GA',
@@ -5516,6 +5536,20 @@
                     ],
                     github: 'https://github.com/Zeroshi/Cerbi.MEL.Governance',
                     nuget: 'https://www.nuget.org/packages/Cerbi.MEL.Governance'
+                },
+                'demo-api': {
+                    icon: '🧪',
+                    title: 'CerbiStream.Governance.Demo.API',
+                    tagline: 'Minimal API for governed logging and runtime validation.',
+                    description: 'Sample CerbiStream application that wires governed logging, runtime validation, and Swagger in a .NET 8 minimal API so teams can try enforcement locally.',
+                    features: [
+                        'CerbiStream logging paired with Cerbi.Governance.Runtime',
+                        'Governance profile loaded from config/cerbi_governance.json or CERBI_GOVERNANCE_PATH',
+                        'Endpoints for /healthz, /governance/profile, and governed POST /event',
+                        'Rejects events with governance violations (e.g., missing required metadata)',
+                        'Swagger UI enabled for hands-on testing'
+                    ],
+                    github: 'https://github.com/Zeroshi/Cerbistream.Governance.Demo.API'
                 },
                 runtime: {
                     icon: '🧮',


### PR DESCRIPTION
## Summary
- add CerbiStream.Governance.Demo.API to the runtime governance ecosystem cards and details
- include features and GitHub link so users can launch the governed minimal API demo
- style API badges used by the new demo entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695206036058832d844f50de080f7860)

## Summary by Sourcery

Add a new governed demo API entry to the runtime governance ecosystem, including its metadata and visual badge styling.

New Features:
- Expose the CerbiStream.Governance.Demo.API as a demo entry in the runtime governance ecosystem with descriptive metadata and links.

Enhancements:
- Introduce a new API badge style to visually distinguish API-based entries in the ecosystem grid.