### PR TITLE
Add privacy, trust, and compliance-safe paperwork

### DIFF
--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -1,0 +1,83 @@
+---
+title: "Cookie Policy"
+description: "How Cerbi uses cookies, analytics, and similar technologies."
+permalink: /docs/cookies/
+layout: default
+last_updated: 2026-07-06
+---
+
+# Cookie Policy
+
+**Last updated:** 2026-07-06
+
+This Cookie Policy explains how Cerbi LLC ("Cerbi," "we," "us," or "our") uses cookies, local storage, pixels, tags, and similar technologies on Cerbi websites and services.
+
+This policy should be read together with our [Privacy Policy](/docs/privacy/).
+
+## 1. What cookies and similar technologies are
+
+Cookies are small files placed on your browser or device. Similar technologies, such as local storage, pixels, tags, and SDK identifiers, can store or read information from your browser or device to operate a website, remember preferences, measure usage, or improve services.
+
+## 2. Categories we may use
+
+### Strictly necessary technologies
+
+These are required for core website or service functionality, security, fraud prevention, preference storage, consent management, and basic operation. These technologies cannot usually be disabled without affecting site functionality.
+
+Examples:
+
+- Security and session protections
+- Consent preference storage
+- Basic site routing or display preferences
+
+### Analytics technologies
+
+These help us understand website usage, page performance, referrals, feature interest, and aggregated visitor behavior.
+
+Examples may include:
+
+- Google Analytics / Google Tag Manager
+- Aggregated page view and interaction metrics
+- Approximate device, browser, and traffic-source data
+
+### Product and behavior analytics
+
+These help us understand how visitors and users interact with product pages, demos, documentation, or product experiences, so we can improve usability and reliability.
+
+Examples may include:
+
+- Amplitude
+- Product/demo interaction events
+- Feature usage and diagnostic events
+
+### Marketing or referral technologies
+
+Cerbi may use limited referral or campaign tracking to understand which campaigns, marketplace pages, documentation, or outreach sources led to website visits or inquiries.
+
+## 3. Analytics tools
+
+Cerbi may use Google Analytics / Google Tag Manager and Amplitude. These tools may collect information such as page views, referrers, device and browser data, approximate location, session identifiers, and interaction events.
+
+Where required by law, Cerbi should load non-essential analytics only after appropriate consent. If you reject non-essential cookies, analytics and product analytics should not be loaded for that browser session except where strictly necessary or otherwise permitted by law.
+
+## 4. Your choices
+
+Where cookie preference controls are available, you may choose:
+
+- **Accept All:** allow strictly necessary, analytics, and product analytics technologies.
+- **Reject All:** allow only strictly necessary technologies.
+- **Manage Preferences:** choose specific categories.
+
+You can also control cookies through your browser settings. Blocking some cookies may affect site functionality.
+
+## 5. Global Privacy Control and browser signals
+
+Where feasible and legally required, Cerbi may honor recognized browser-based opt-out or privacy signals, such as Global Privacy Control, for applicable processing.
+
+## 6. Changes
+
+We may update this Cookie Policy from time to time. Material changes will be posted with an updated effective date.
+
+## 7. Contact
+
+Questions about cookies or privacy choices can be sent to **hello@cerbi.io**.

--- a/docs/dpa.md
+++ b/docs/dpa.md
@@ -1,0 +1,54 @@
+---
+title: "Data Processing Addendum"
+description: "Data Processing Addendum availability for Cerbi customers."
+permalink: /docs/dpa/
+layout: default
+last_updated: 2026-07-06
+---
+
+# Data Processing Addendum
+
+**Last updated:** 2026-07-06
+
+Cerbi LLC ("Cerbi") offers a Data Processing Addendum ("DPA") for customers where Cerbi processes personal data on the customer's behalf.
+
+This page is a notice of availability. It is not itself a complete DPA and does not replace a signed customer agreement, marketplace agreement, order form, or negotiated data processing terms.
+
+## When a DPA may be needed
+
+A DPA may be appropriate when:
+
+- A customer uses Cerbi products or services to process personal data.
+- Cerbi acts as a processor, service provider, or similar role for customer-controlled data.
+- The customer is subject to privacy laws or contractual obligations that require data processing terms.
+- The customer needs written terms covering subprocessors, security measures, deletion, return, audit assistance, or breach notification.
+
+## Typical DPA topics
+
+A customer DPA may address:
+
+- Controller and processor roles.
+- Customer instructions.
+- Confidentiality obligations.
+- Security measures.
+- Subprocessors and notice rights.
+- International transfer mechanisms.
+- Assistance with privacy requests.
+- Assistance with security, audit, and impact assessment obligations.
+- Deletion or return of customer data.
+- Incident and breach notification.
+- Audit and documentation support.
+
+## Customer responsibility
+
+Customers are responsible for determining whether personal data is processed through Cerbi products, configuring governance policies appropriately, avoiding unnecessary sensitive data in logs, and ensuring that their use of Cerbi complies with applicable laws, contracts, and internal policies.
+
+## Request a DPA
+
+To request Cerbi's DPA or discuss data processing terms, contact:
+
+**hello@cerbi.io**
+
+## No compliance certification
+
+Cerbi does not provide legal advice and does not certify DORA, GDPR, CCPA/CPRA, HIPAA, SOC 2, or other regulatory compliance. Cerbi products can support audit preparation, logging governance evidence, data minimization, and control review, but customers remain responsible for their overall compliance programs.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,45 +1,169 @@
 ---
 title: "Privacy Policy"
-description: "How Cerbi LLC collects, uses, and protects information."
+description: "How Cerbi LLC collects, uses, shares, and protects information."
 permalink: /docs/privacy/
 layout: default
+last_updated: 2026-07-06
 ---
 
 # Privacy Policy
 
-**Last updated:** 2025-09-25
+**Last updated:** 2026-07-06
 
-Cerbi LLC ("Cerbi", "we", "us") provides developer tooling for structured logging, governance, and observability.
+Cerbi LLC ("Cerbi," "we," "us," or "our") provides source-side logging governance, governance scoring, policy management, and evidence-generation tools, including CerbiStream and CerbiShield.
 
-## What we collect
+This Privacy Policy explains how we collect, use, disclose, retain, and protect information when you visit Cerbi websites, contact us, use our documentation or demos, communicate with us, or use Cerbi products and services.
 
-- **Site analytics:** page views, referrers, and aggregated events (GA4).
-- **Contact form:** name, email, company, message, and any attachments you send.
-- **Product telemetry (optional):** if enabled in Cerbi libraries, we collect counts and error codes only; no PII by default.
+This Privacy Policy is not legal advice and does not certify compliance with DORA, GDPR, CCPA/CPRA, HIPAA, SOC 2, or any other legal or regulatory framework.
 
-## How we use data
+## 1. Roles and scope
 
-- To respond to inquiries, provide services, improve the site and product, and meet legal requirements.
+For website, marketing, contact, support, and account-related information, Cerbi generally acts as an independent controller of personal information.
 
-## Sharing
+For customer-controlled product data processed through Cerbi products or services, Cerbi may act as a processor, service provider, or similar role under an applicable customer agreement, data processing addendum, marketplace agreement, or written instruction. The customer remains responsible for determining what data is submitted to Cerbi products and for ensuring the customer has the necessary rights, notices, and legal bases for that processing.
 
-We do not sell personal data. We may share information with service providers under contract (for example, hosting and analytics) or as required by law.
+Cerbi products are designed to help customers reduce logging data risk by applying source-side governance, redaction, blocking, policy evidence, and audit-support controls. Customers should avoid sending unnecessary personal data, sensitive data, secrets, credentials, or regulated data to logs.
 
-## Data retention
+## 2. Information we collect
 
-We keep data only as long as needed for the purposes above or as required by law, then delete or anonymize it.
+We may collect the following categories of information:
 
-## Your choices
+### Website and analytics information
 
-Email us to request access, correction, or deletion of your data: **hello@cerbi.io**.
+- Page views, referrers, approximate location derived from IP address, browser type, device type, operating system, session information, and interaction events.
+- Cookie, local storage, and similar browser identifiers.
+- Consent or preference settings related to cookies and analytics.
 
-## Security
+### Contact, sales, and support information
 
-We apply reasonable technical and organizational safeguards. See our [Security Overview](/docs/security/).
+- Name, email address, company, job title, message content, attachments, and related correspondence.
+- Information you provide when requesting a demo, support, documentation, marketplace information, or security review.
 
-## Contact
+### Product and telemetry information
+
+- Product configuration, product version, feature usage, health events, error codes, event counts, and diagnostic metadata.
+- Governance-related records such as policy names, policy versions, policy hashes, governance decisions, enforcement actions, violations, exceptions, approvals, audit records, deployment history, and evidence export metadata.
+- Optional telemetry, where enabled, is intended to avoid collecting personal data by default. Customers control whether and how telemetry is enabled in their environments.
+
+### Customer-controlled data
+
+Depending on configuration, customers may process logging metadata, application names, environment names, event field names, governance rule definitions, exception records, user identifiers, or other data through Cerbi products. Customers are responsible for configuring governance policies to minimize, redact, or block unnecessary or sensitive data.
+
+### Marketplace and transaction information
+
+If you procure Cerbi through Microsoft Marketplace or another marketplace, we may receive business contact, subscription, tenant, transaction, plan, and entitlement information needed to provide, support, and administer the service.
+
+## 3. Sources of information
+
+We collect information from:
+
+- You or your organization.
+- Your browser or device when you visit our website.
+- Cerbi products and services, where enabled or configured.
+- Marketplace, hosting, analytics, security, and support providers.
+- Public business sources, where used for sales, support, or fraud prevention.
+
+## 4. How we use information
+
+We use information to:
+
+- Operate, secure, maintain, and improve Cerbi websites, products, and services.
+- Respond to inquiries, support requests, security reports, and business communications.
+- Provide demos, documentation, onboarding, marketplace fulfillment, and customer support.
+- Monitor product reliability, troubleshoot issues, and improve product quality.
+- Generate governance, audit-preparation, and evidence records requested by customers.
+- Enforce policies, protect against abuse, prevent fraud, and maintain security.
+- Comply with legal, regulatory, contractual, tax, accounting, and marketplace obligations.
+- Send product, security, or administrative notices.
+- Send marketing communications where permitted by law and subject to opt-out rights.
+
+## 5. EU/UK legal bases
+
+For individuals in the European Economic Area, United Kingdom, or Switzerland, we rely on one or more of the following legal bases, depending on the context:
+
+- **Contract:** to provide requested services, support, documentation, marketplace fulfillment, or account administration.
+- **Legitimate interests:** to secure, improve, and operate our services; respond to business inquiries; prevent abuse; and understand website/product usage, balanced against individual rights.
+- **Consent:** for non-essential cookies, analytics, marketing communications, or other processing where consent is required.
+- **Legal obligation:** to comply with applicable laws, tax obligations, accounting requirements, sanctions/export rules, or lawful requests.
+- **Customer instructions:** where Cerbi acts as a processor or service provider for customer-controlled product data under an applicable agreement.
+
+## 6. Cookies, analytics, and similar technologies
+
+Cerbi may use cookies, local storage, pixels, and similar technologies for site operation, security, preferences, analytics, and product improvement.
+
+We may use analytics providers such as Google Analytics / Google Tag Manager and Amplitude to understand website and product usage. Where required by law, non-essential analytics should be used only with consent. You can review more detail in our [Cookie Policy](/docs/cookies/).
+
+## 7. How we share information
+
+We do not sell personal information.
+
+We may disclose information to:
+
+- Service providers and subprocessors that help us host, secure, analyze, support, and operate Cerbi websites and services.
+- Marketplace providers, such as Microsoft, where needed for procurement, subscription, entitlement, billing, or support flows.
+- Professional advisors, auditors, insurers, or legal counsel.
+- Authorities or third parties when required by law, legal process, security investigation, or to protect rights and safety.
+- Successors or participants in a merger, acquisition, financing, reorganization, or similar business transaction.
+
+See our [Subprocessors and Service Providers](/docs/subprocessors/) page for more information.
+
+## 8. International transfers
+
+Cerbi is based in the United States. Information may be processed in the United States and other countries where Cerbi or our service providers operate. Where required, we use appropriate safeguards for international transfers, which may include contractual protections, customer agreements, data processing terms, or other lawful transfer mechanisms.
+
+## 9. Retention
+
+We retain information only as long as reasonably necessary for the purposes described in this Privacy Policy, including to provide services, comply with legal obligations, resolve disputes, enforce agreements, maintain security, and support audit or business records.
+
+Retention periods vary based on the type of information, customer configuration, contractual terms, legal requirements, and operational needs. Customer-controlled product data may be retained according to customer instructions, product configuration, or applicable agreements.
+
+## 10. Security
+
+We use reasonable technical and organizational safeguards intended to protect information from unauthorized access, disclosure, alteration, or destruction. Cerbi products are designed to support source-side data minimization, redaction, blocking, policy versioning, audit records, evidence exports, and customer-controlled governance.
+
+No method of transmission or storage is completely secure. Customers are responsible for configuring their systems, logs, policies, credentials, access controls, and downstream observability tools appropriately.
+
+See our [Security Overview](/docs/security/).
+
+## 11. Your choices and rights
+
+Depending on your location and relationship with Cerbi, you may have rights to:
+
+- Access personal information.
+- Correct inaccurate information.
+- Delete information.
+- Object to or restrict certain processing.
+- Withdraw consent where processing is based on consent.
+- Request portability of certain information.
+- Opt out of marketing communications.
+- Lodge a complaint with a data protection authority.
+
+To exercise rights, contact **hello@cerbi.io**. We may need to verify your identity and may direct customer-controlled product data requests to the relevant customer administrator.
+
+## 12. California privacy notice
+
+We do not sell personal information. We do not knowingly share personal information for cross-context behavioral advertising in a way that would require a sale/share opt-out under California law unless otherwise disclosed through cookie or consent controls.
+
+California residents may have rights to know/access, delete, correct, limit certain uses of sensitive personal information, and opt out of sale/share where applicable. Cerbi does not discriminate against individuals for exercising privacy rights.
+
+To submit a California privacy request, email **hello@cerbi.io**.
+
+## 13. Sensitive data
+
+Cerbi products are intended to help reduce sensitive data exposure in logs. Customers should not intentionally submit sensitive personal information, credentials, secrets, payment card data, protected health information, or other regulated data to Cerbi or downstream logs unless the customer has appropriate rights, controls, agreements, and safeguards in place.
+
+## 14. Children
+
+Cerbi websites and services are not directed to children under 13, and we do not knowingly collect personal information from children under 13.
+
+## 15. Changes to this Privacy Policy
+
+We may update this Privacy Policy from time to time. Material changes will be posted on this page with an updated effective date.
+
+## 16. Contact
 
 Cerbi LLC  
 7901 4TH ST N STE 300  
 St. Petersburg, FL 33702  
-hello@cerbi.io
+United States  
+Email: **hello@cerbi.io**

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,32 +1,111 @@
 ---
 title: "Security Overview"
-description: "How Cerbi approaches security, privacy, and safe telemetry."
+description: "How Cerbi approaches security, privacy, source-side logging governance, and evidence generation."
 permalink: /docs/security/
 layout: default
-last_updated: 2025-09-25
+last_updated: 2026-07-06
 ---
 
 # Security Overview
 
-**Architecture**
-- Source-governed telemetry: build-time analyzer + runtime validator
-- Encryption via `IEncryption` implementations: AES, Base64, or NoOp
-- File fallback with rotation for resilient logging
+**Last updated:** 2026-07-06
 
-**Data minimization**
-- PII redaction controlled by policy
-- Relax mode preserves signals while tagging violations
-- Stable schemas reduce accidental leakage
+Cerbi products are designed to help teams reduce logging data risk by applying governance before log events reach downstream observability, SIEM, analytics, or storage systems.
 
-**Access control (CerbiShield, beta)**
-- Role-based access control (RBAC)
-- Profile versioning with audit history and rollbacks
+This page summarizes Cerbi's security posture and product security model. It is not a compliance certification or legal opinion.
 
-**Handling sensitive data**
-- Recommended: exclude PII from logs entirely
-- If business-necessary, mask at source per policy and document justification
+## Source-side logging governance
 
-**Reporting**
-- Please report vulnerabilities to **security@cerbi.io**
-- Include reproduction steps, expected vs. actual behavior, and impact
-- We will acknowledge receipt and follow up with status updates
+Cerbi's core security model is source-side governance:
+
+- Evaluate log events before they leave the application boundary.
+- Detect sensitive, forbidden, missing, or malformed fields.
+- Redact or block risky values according to policy.
+- Preserve evidence of which policy evaluated an event.
+- Keep existing log routing, SIEM, APM, and observability tools in place.
+
+Cerbi does not replace Splunk, Datadog, Azure Monitor, OpenTelemetry, SIEM platforms, or application logging frameworks. It adds governance before data reaches those systems.
+
+## Data minimization by design
+
+Cerbi encourages teams to avoid putting personal data, credentials, secrets, payment data, protected health information, or other sensitive data into logs.
+
+Where logging sensitive operational signals is business-necessary, Cerbi can help teams:
+
+- Classify fields by policy.
+- Redact or block fields at the source.
+- Preserve violations and enforcement evidence.
+- Review exceptions and relaxed-mode events.
+- Identify ungoverned or unscored application environments.
+
+## Policy versioning and evidence
+
+CerbiShield can support policy and evidence records such as:
+
+- Governance profile ID.
+- Governance profile version.
+- Governance profile hash.
+- Governance decision.
+- Enforcement action.
+- Exception ID.
+- Exception reason.
+- Exception approver.
+- Exception expiration.
+- Deployment and audit history.
+
+These records are intended to support engineering review, security review, audit preparation, and CISO reporting.
+
+## Evidence Center and manifest hash
+
+CerbiShield Evidence Center packages governance, scoring, audit, deployment, violation, and rule records into review-friendly exports.
+
+Exports may include CSV and JSON manifest records with a manifest hash. This helps teams preserve evidence of what was exported, when it was generated, what filters were used, and which source records were included.
+
+## Access control and customer environments
+
+CerbiShield may include role-based access controls, tenant-aware APIs, policy management, and customer-controlled deployment patterns.
+
+Depending on deployment model, CerbiShield components may run in a customer cloud tenant or customer-controlled environment. Customers remain responsible for configuring identity, access controls, network controls, logging destinations, retention, and downstream data systems.
+
+## Encryption and handling sensitive data
+
+Cerbi libraries may support encryption or transformation options such as AES, Base64, or no-op implementations depending on package and configuration.
+
+Recommended practices:
+
+- Exclude sensitive data from logs whenever possible.
+- Use source-side redaction or blocking for risky fields.
+- Avoid logging secrets, credentials, tokens, payment data, or protected health information.
+- Document any approved exception and expiration.
+- Review relaxed-mode usage regularly.
+
+## Vulnerability reporting
+
+Please report suspected vulnerabilities to:
+
+**security@cerbi.io**
+
+Include:
+
+- Affected product or package.
+- Version or commit, if known.
+- Reproduction steps.
+- Expected and actual behavior.
+- Potential impact.
+- Whether the issue may expose customer data.
+
+Cerbi will review and respond to security reports in good faith.
+
+## Compliance-safe positioning
+
+CerbiShield provides source-side logging governance and evidence that can support audit preparation and control review.
+
+Cerbi does not provide legal advice and does not certify DORA, GDPR, CCPA/CPRA, HIPAA, SOC 2, or other regulatory compliance. Customers remain responsible for their own compliance programs, system configuration, policies, notices, retention, and legal obligations.
+
+## Related documents
+
+- [Privacy Policy](/docs/privacy/)
+- [Cookie Policy](/docs/cookies/)
+- [Subprocessors and Service Providers](/docs/subprocessors/)
+- [Data Processing Addendum](/docs/dpa/)
+- [Trust and Compliance-Safe Positioning](/docs/trust/)

--- a/docs/subprocessors.md
+++ b/docs/subprocessors.md
@@ -1,0 +1,41 @@
+---
+title: "Subprocessors and Service Providers"
+description: "Service providers Cerbi may use to operate, support, secure, and improve its websites and services."
+permalink: /docs/subprocessors/
+layout: default
+last_updated: 2026-07-06
+---
+
+# Subprocessors and Service Providers
+
+**Last updated:** 2026-07-06
+
+Cerbi LLC ("Cerbi," "we," "us," or "our") may use third-party service providers and subprocessors to operate, secure, support, distribute, analyze, and improve Cerbi websites, products, and services.
+
+This page is intended to provide transparency. The actual providers used for a customer may depend on the product, deployment model, marketplace channel, agreement, and customer configuration.
+
+## Current or likely service providers
+
+| Provider | Purpose | Data categories |
+|---|---|---|
+| GitHub | Source hosting, CI/CD, package and container registry, issue tracking, release management | Repository data, workflow metadata, package/container metadata, account identifiers |
+| Microsoft Azure | Hosting, deployment, storage, identity, marketplace, monitoring, and cloud services where applicable | Customer tenant/deployment metadata, service logs, operational data, account/contact data where applicable |
+| Microsoft Marketplace / AppSource | Marketplace listing, subscription, procurement, entitlement, and customer administration flows | Business contact data, subscription data, tenant/account identifiers, transaction metadata |
+| Google Analytics / Google Tag Manager | Website analytics, traffic measurement, and performance insights where enabled and consented | Page views, referrers, device/browser metadata, approximate location, interaction events |
+| Amplitude | Product, demo, website, or behavior analytics where enabled and consented | Event data, session identifiers, product interaction metadata, device/browser metadata |
+| Hosting/CDN provider | Website hosting, content delivery, availability, and performance | IP address, request metadata, browser/device metadata, operational logs |
+| Email/contact provider | Contact, support, sales, security, and administrative communications where used | Name, email address, company, message content, attachments, communication metadata |
+
+## Customer-controlled deployments
+
+Some CerbiShield capabilities may be deployed into or operated within a customer's cloud tenant or controlled environment. In those cases, the customer may control additional infrastructure, logs, data retention, access controls, integrations, and downstream observability tools.
+
+## Subprocessor changes
+
+Providers may change over time as Cerbi evolves. Cerbi will update this page when material changes are made to the service provider list.
+
+Customers with a signed agreement or Data Processing Addendum may receive additional notice rights according to those terms.
+
+## Contact
+
+Questions about subprocessors or service providers can be sent to **hello@cerbi.io**.

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -1,0 +1,85 @@
+---
+title: "Trust and Compliance-Safe Positioning"
+description: "How Cerbi supports logging governance evidence, audit preparation, and data minimization without claiming compliance certification."
+permalink: /docs/trust/
+layout: default
+last_updated: 2026-07-06
+---
+
+# Trust and Compliance-Safe Positioning
+
+**Last updated:** 2026-07-06
+
+CerbiShield helps platform, security, compliance, and engineering teams generate evidence for source-side logging governance. It is designed to help teams understand which logging policies were active, how events were evaluated, what enforcement actions were taken, and which exceptions were approved.
+
+Cerbi does not provide legal advice or compliance certification. CerbiShield helps teams generate logging governance evidence that can support audit preparation and control review.
+
+## DORA-aligned logging governance evidence
+
+The Digital Operational Resilience Act (DORA) raises expectations for ICT risk management, operational resilience, incident readiness, technology oversight, and evidence-based control review.
+
+CerbiShield supports a DORA-aligned logging governance story by helping teams produce evidence about:
+
+- Applications and environments with governance coverage.
+- Active governance profiles and policy bindings.
+- Policy versions and policy hashes.
+- Governance decisions such as allowed, warned, redacted, blocked, or relaxed.
+- Enforcement actions taken at the source.
+- Violations by severity.
+- Relaxed-mode events.
+- Approved exceptions and approvals.
+- Deployment records and audit history.
+- Evidence exports with manifest hashes.
+
+CerbiShield does not certify DORA compliance. It provides logging governance evidence that can support reviews, audits, and internal control discussions.
+
+## GDPR-style accountability and data minimization support
+
+CerbiShield supports GDPR-style accountability and data minimization by helping teams govern logs before sensitive or unnecessary fields reach downstream observability, SIEM, analytics, or storage systems.
+
+CerbiShield can help teams:
+
+- Detect sensitive, forbidden, missing, or malformed fields.
+- Redact or block risky fields at the source.
+- Preserve evidence of policy version, policy hash, decision, and enforcement action.
+- Review approved exceptions and expiration dates.
+- Identify ungoverned or unscored application environments.
+- Export records for security, privacy, compliance, and engineering review.
+
+CerbiShield does not certify GDPR compliance. Customers remain responsible for legal bases, notices, retention, access controls, downstream systems, data subject rights, and overall compliance obligations.
+
+## Source-side governance model
+
+CerbiShield is designed to complement existing logging, SIEM, APM, and observability tools. It does not replace Splunk, Datadog, Azure Monitor, OpenTelemetry, SIEM platforms, or application logging frameworks.
+
+Instead, CerbiShield adds governance before logs reach those tools.
+
+## Evidence Center
+
+The Evidence Center packages governance, scoring, audit, deployment, violation, and rule records into auditor- and CISO-friendly exports.
+
+Evidence exports may include:
+
+- Application coverage.
+- Active policies and hashes.
+- Violation counts.
+- Relaxed events.
+- Exception and approval records.
+- Deployment records.
+- Source record counts.
+- Export manifest hash.
+
+## Key disclaimers
+
+- Cerbi does not provide legal advice.
+- Cerbi does not certify DORA, GDPR, CCPA/CPRA, HIPAA, SOC 2, or other regulatory compliance.
+- CerbiShield provides logging governance evidence that can support audit preparation and control review.
+- Customers remain responsible for their own compliance programs, system configuration, access controls, retention, notices, and legal obligations.
+
+## Related documents
+
+- [Privacy Policy](/docs/privacy/)
+- [Cookie Policy](/docs/cookies/)
+- [Security Overview](/docs/security/)
+- [Subprocessors and Service Providers](/docs/subprocessors/)
+- [Data Processing Addendum](/docs/dpa/)

--- a/downloads/Cerbi-Privacy-Policy.md
+++ b/downloads/Cerbi-Privacy-Policy.md
@@ -1,48 +1,84 @@
 # Cerbi Privacy Policy
-**Effective date:** 2025-09-25
 
-This Privacy Policy explains how **Cerbi LLC** (“Cerbi”, “we”, “us”) collects, uses, and shares information when you use our websites (including **cerbi.io**) and our software and services, including CerbiStream, Cerbi.MEL.Governance, and CerbiShield (collectively, the “Services”).
+**Effective date:** 2026-07-06
 
-## Summary
-- We collect the minimum data needed to operate the Services, measure usage, and respond to you.
-- We don’t sell your personal information.
-- You control your marketing preferences and can request access or deletion of your data.
+Cerbi LLC ("Cerbi," "we," "us," or "our") provides source-side logging governance, governance scoring, policy management, and evidence-generation tools, including CerbiStream and CerbiShield.
 
-## Information We Collect
-**Provided by you.** Contact details (e.g., name, email), company name, role, and message content you submit via forms or email.**Automatically.** Device/browser info, IP address, pages viewed, and product usage events (e.g., button clicks) collected via standard web analytics (e.g., Google Analytics).**From customers.** If you connect our SDKs, telemetry and logs you choose to emit may pass through our systems for governance analysis. You remain responsible for the content of that telemetry.
+This Privacy Policy explains how we collect, use, disclose, retain, and protect information when you visit Cerbi websites, contact us, use our documentation or demos, communicate with us, or use Cerbi products and services.
 
-## How We Use Information
-- Provide, secure, and improve the Services
-- Analyze usage to guide product decisions and resolve issues
-- Communicate with you about updates, security notices, and support
-- Comply with law and enforce agreements
+This Privacy Policy is not legal advice and does not certify compliance with DORA, GDPR, CCPA/CPRA, HIPAA, SOC 2, or any other legal or regulatory framework.
 
-## Legal Bases (EEA/UK)
-We process personal data on the basis of **legitimate interests** (product analytics, security), **contract** (providing the Services), and **consent** (marketing emails/cookies where required).
+## 1. Roles and scope
 
-## Sharing
-We use service providers (e.g., hosting, analytics, support) under contract who process data for us and under our instructions. We may disclose information to comply with law or in connection with a business transaction. We do not sell personal information.
+For website, marketing, contact, support, and account-related information, Cerbi generally acts as an independent controller of personal information.
 
-## Data Retention
-We keep information for as long as needed to provide the Services and for legitimate business/legal purposes. You can request deletion; see **Your Rights** below.
+For customer-controlled product data processed through Cerbi products or services, Cerbi may act as a processor, service provider, or similar role under an applicable customer agreement, data processing addendum, marketplace agreement, or written instruction. The customer remains responsible for determining what data is submitted to Cerbi products and for ensuring the customer has the necessary rights, notices, and legal bases for that processing.
 
-## Security
-We apply administrative, technical, and physical safeguards. No method of transmission or storage is 100% secure.
+Cerbi products are designed to help customers reduce logging data risk by applying source-side governance, redaction, blocking, policy evidence, and audit-support controls. Customers should avoid sending unnecessary personal data, sensitive data, secrets, credentials, or regulated data to logs.
 
-## Your Rights
-Depending on your region, you may have rights to access, correct, delete, or restrict processing of your data, and to object or port data. To exercise a right, email **hello@cerbi.io**.
+## 2. Information we collect
 
-## International Transfers
-We operate in the United States and may transfer data to the U.S. and other countries that may not have equivalent data protection laws. We use appropriate safeguards for such transfers when required.
+We may collect the following categories of information:
 
-## Children
-The Services are not directed to children under 13, and we do not knowingly collect their personal information.
+- Website and analytics information, including page views, referrers, approximate location derived from IP address, browser type, device type, operating system, session information, interaction events, and consent preferences.
+- Contact, sales, and support information, including name, email address, company, job title, message content, attachments, and related correspondence.
+- Product and telemetry information, including product configuration, product version, feature usage, health events, error codes, event counts, and diagnostic metadata.
+- Governance-related records, such as policy names, policy versions, policy hashes, governance decisions, enforcement actions, violations, exceptions, approvals, audit records, deployment history, and evidence export metadata.
+- Customer-controlled data, depending on customer configuration.
+- Marketplace and transaction information, if you procure Cerbi through a marketplace.
 
-## Do Not Track
-We do not respond to Do Not Track signals.
+## 3. Sources of information
 
-## Contact
-**CERBI LLC**7901 4TH ST N STE 300, ST. PETERSBURG, FL 33702, USAEmail: **hello@cerbi.io**
+We collect information from you or your organization, your browser or device, Cerbi products and services where enabled, marketplace and hosting providers, analytics providers, security/support providers, and public business sources where used for sales, support, or fraud prevention.
 
-## Changes
-We may update this Policy from time to time. The “Effective date” above reflects the latest version.
+## 4. How we use information
+
+We use information to operate, secure, maintain, and improve Cerbi websites, products, and services; respond to inquiries and support requests; provide demos and documentation; monitor product reliability; generate customer-requested governance and evidence records; prevent abuse; comply with legal obligations; and send permitted administrative or marketing communications.
+
+## 5. EU/UK legal bases
+
+For individuals in the European Economic Area, United Kingdom, or Switzerland, we rely on one or more legal bases depending on context: contract, legitimate interests, consent, legal obligation, or customer instructions where Cerbi acts as processor or service provider.
+
+## 6. Cookies and analytics
+
+Cerbi may use cookies, local storage, pixels, and similar technologies for site operation, security, preferences, analytics, and product improvement. We may use analytics providers such as Google Analytics / Google Tag Manager and Amplitude. Where required by law, non-essential analytics should be used only with consent.
+
+## 7. Sharing
+
+We do not sell personal information. We may disclose information to service providers and subprocessors, marketplace providers, professional advisors, authorities when required by law, or successors in a merger, acquisition, financing, reorganization, or similar business transaction.
+
+## 8. International transfers
+
+Cerbi is based in the United States. Information may be processed in the United States and other countries where Cerbi or our service providers operate. Where required, we use appropriate safeguards for international transfers, which may include contractual protections, customer agreements, data processing terms, or other lawful transfer mechanisms.
+
+## 9. Retention
+
+We retain information only as long as reasonably necessary for the purposes described in this Privacy Policy, including to provide services, comply with legal obligations, resolve disputes, enforce agreements, maintain security, and support audit or business records.
+
+## 10. Security
+
+We use reasonable technical and organizational safeguards intended to protect information from unauthorized access, disclosure, alteration, or destruction. Cerbi products are designed to support source-side data minimization, redaction, blocking, policy versioning, audit records, evidence exports, and customer-controlled governance.
+
+## 11. Your choices and rights
+
+Depending on your location and relationship with Cerbi, you may have rights to access, correct, delete, object to or restrict processing, withdraw consent, request portability, opt out of marketing, or lodge a complaint with a data protection authority. To exercise rights, contact **hello@cerbi.io**.
+
+## 12. California privacy notice
+
+We do not sell personal information. We do not knowingly share personal information for cross-context behavioral advertising in a way that would require a sale/share opt-out unless otherwise disclosed through cookie or consent controls. California residents may have rights to know/access, delete, correct, limit certain uses of sensitive personal information, and opt out of sale/share where applicable.
+
+## 13. Sensitive data
+
+Cerbi products are intended to help reduce sensitive data exposure in logs. Customers should not intentionally submit sensitive personal information, credentials, secrets, payment card data, protected health information, or other regulated data to Cerbi or downstream logs unless the customer has appropriate rights, controls, agreements, and safeguards in place.
+
+## 14. Children
+
+Cerbi websites and services are not directed to children under 13, and we do not knowingly collect personal information from children under 13.
+
+## 15. Contact
+
+**CERBI LLC**  
+7901 4TH ST N STE 300  
+ST. PETERSBURG, FL 33702  
+United States  
+Email: **hello@cerbi.io**

--- a/downloads/Cerbi-Terms-of-Service.md
+++ b/downloads/Cerbi-Terms-of-Service.md
@@ -1,55 +1,79 @@
 # Cerbi Terms of Service
+
 **Effective date:** 2025-09-25
 
 These Terms of Service (“Terms”) govern your access to and use of the websites and products provided by **CERBI LLC** (“Cerbi”, “we”, “us”). By using the Services, you agree to these Terms.
 
 ## 1. The Services
-Cerbi provides developer tooling for structured logging and governance, including CerbiStream, Cerbi.MEL.Governance, and CerbiShield (beta). Some components may be pre-release and subject to change.
+
+Cerbi provides developer tooling for structured logging and governance, including CerbiStream, Cerbi.MEL.Governance, and CerbiShield. Some components may be pre-release and subject to change.
 
 ## 2. Accounts & Eligibility
+
 You must be at least 18 and capable of forming a binding contract. You are responsible for activity under your account and must keep credentials confidential.
 
 ## 3. Acceptable Use
-You will not: (a) violate law; (b) reverse engineer, decompile, or bypass technical limits; (c) interfere with security or integrity; (d) send malicious or unauthorized data; or (e) use the Services to process unlawful data (e.g., certain sensitive personal data) without appropriate agreements/controls.
+
+You will not: (a) violate law; (b) reverse engineer, decompile, or bypass technical limits; (c) interfere with security or integrity; (d) send malicious or unauthorized data; or (e) use the Services to process unlawful data or sensitive personal data without appropriate agreements, rights, notices, and controls.
 
 ## 4. Customer Data & Telemetry
+
 You retain all rights to your data and telemetry. You grant Cerbi a limited license to process such data solely to provide and improve the Services and to comply with law. You are responsible for obtaining all necessary rights and notices for data you provide.
 
 ## 5. Privacy
+
 Use of the Services is subject to our Privacy Policy, which is incorporated by reference.
 
 ## 6. Beta Features
-Beta or preview features (including CerbiShield Beta) are provided **as-is** without warranties and may be discontinued. Usage may be limited and may include additional terms.
+
+Beta or preview features, including CerbiShield beta features, are provided **as-is** without warranties and may be discontinued. Usage may be limited and may include additional terms.
 
 ## 7. Fees
+
 If paid plans are introduced, fees, terms, and billing cycles will be disclosed on an order form or pricing page. Until then, certain components may be offered at no cost or under promotional terms.
 
 ## 8. Intellectual Property
+
 Cerbi and our licensors retain all rights in the Services, documentation, logos, and trademarks. No rights are granted except as expressly set forth in these Terms.
 
 ## 9. Confidentiality
+
 Each party may disclose non-public information to the other. The receiving party will protect such information with reasonable care and use it only for the permitted purpose.
 
 ## 10. Warranties & Disclaimers
+
 THE SERVICES ARE PROVIDED “AS IS” AND “AS AVAILABLE” WITHOUT WARRANTIES OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY LAW, CERBI DISCLAIMS ALL WARRANTIES, INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
 
+Cerbi does not provide legal advice and does not certify DORA, GDPR, CCPA/CPRA, HIPAA, SOC 2, or other regulatory compliance. Cerbi products may support audit preparation, logging governance evidence, data minimization, and control review, but you remain responsible for your own compliance program and legal obligations.
+
 ## 11. Limitation of Liability
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT WILL CERBI BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR LOSS OF PROFITS, REVENUE, DATA, OR BUSINESS, EVEN IF ADVISED OF THE POSSIBILITY. CERBI’S TOTAL LIABILITY FOR ANY CLAIM WILL NOT EXCEED THE AMOUNTS PAID BY YOU TO CERBI FOR THE SERVICES IN THE 12 MONTHS BEFORE THE EVENT GIVING RISE TO THE CLAIM, OR \$100 IF NO FEES WERE PAID.
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT WILL CERBI BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR LOSS OF PROFITS, REVENUE, DATA, OR BUSINESS, EVEN IF ADVISED OF THE POSSIBILITY. CERBI’S TOTAL LIABILITY FOR ANY CLAIM WILL NOT EXCEED THE AMOUNTS PAID BY YOU TO CERBI FOR THE SERVICES IN THE 12 MONTHS BEFORE THE EVENT GIVING RISE TO THE CLAIM, OR $100 IF NO FEES WERE PAID.
 
 ## 12. Indemnification
+
 You will defend and indemnify Cerbi from claims arising out of your data, your use of the Services, or your breach of these Terms.
 
 ## 13. Suspension & Termination
+
 We may suspend or terminate access for violation of these Terms, security risks, or non-payment. You may stop using the Services at any time.
 
 ## 14. Governing Law; Venue
+
 These Terms are governed by the laws of the State of Florida, excluding conflicts of law rules. Courts in Pinellas County, Florida will have exclusive jurisdiction.
 
 ## 15. Export
+
 You must comply with U.S. and other applicable export laws.
 
 ## 16. Changes to Terms
+
 We may modify these Terms; material changes will be posted. Continued use after changes constitutes acceptance.
 
 ## 17. Contact
-**CERBI LLC**7901 4TH ST N STE 300, ST. PETERSBURG, FL 33702, USAEmail: **hello@cerbi.io**
+
+**CERBI LLC**  
+7901 4TH ST N STE 300  
+ST. PETERSBURG, FL 33702  
+United States  
+Email: **hello@cerbi.io**

--- a/public_documents/privacy.md
+++ b/public_documents/privacy.md
@@ -1,45 +1,77 @@
 ---
 title: "Privacy Policy"
-description: "How Cerbi collects, uses, and protects information."
+description: "How Cerbi LLC collects, uses, shares, and protects information."
 permalink: /docs/privacy/
 layout: default
+last_updated: 2026-07-06
 ---
 
 # Privacy Policy
 
-**Last updated:** 2025-09-25
+**Last updated:** 2026-07-06
 
-Cerbi LLC ("Cerbi", "we", "us") provides developer tooling for structured logging, governance, and observability.
+Cerbi LLC ("Cerbi," "we," "us," or "our") provides source-side logging governance, governance scoring, policy management, and evidence-generation tools, including CerbiStream and CerbiShield.
 
-## What we collect
+This Privacy Policy explains how we collect, use, disclose, retain, and protect information when you visit Cerbi websites, contact us, use our documentation or demos, communicate with us, or use Cerbi products and services.
 
-- **Site analytics:** page views, referrers, and aggregated events (GA4).
-- **Contact form:** name, email, company, message, and any attachments you send.
-- **Product telemetry (optional):** if enabled in Cerbi libraries, we collect counts and error codes only; no PII by default.
+This Privacy Policy is not legal advice and does not certify compliance with DORA, GDPR, CCPA/CPRA, HIPAA, SOC 2, or any other legal or regulatory framework.
 
-## How we use data
+## 1. Roles and scope
 
-- To respond to inquiries, provide services, improve the site and product, and meet legal requirements.
+For website, marketing, contact, support, and account-related information, Cerbi generally acts as an independent controller of personal information.
 
-## Sharing
+For customer-controlled product data processed through Cerbi products or services, Cerbi may act as a processor, service provider, or similar role under an applicable customer agreement, data processing addendum, marketplace agreement, or written instruction. The customer remains responsible for determining what data is submitted to Cerbi products and for ensuring the customer has the necessary rights, notices, and legal bases for that processing.
 
-We do not sell personal data. We may share information with service providers under contract (for example, hosting and analytics) or as required by law.
+Cerbi products are designed to help customers reduce logging data risk by applying source-side governance, redaction, blocking, policy evidence, and audit-support controls. Customers should avoid sending unnecessary personal data, sensitive data, secrets, credentials, or regulated data to logs.
 
-## Data retention
+## 2. Information we collect
 
-We keep data only as long as needed for the purposes above or as required by law, then delete or anonymize it.
+We may collect website and analytics information, contact and support information, marketplace and transaction information, optional product telemetry, and customer-controlled product data depending on customer configuration and agreements.
 
-## Your choices
+## 3. How we use information
 
-Email us to request access, correction, or deletion of your data: **hello@cerbi.io**.
+We use information to operate, secure, maintain, and improve Cerbi websites, products, and services; respond to inquiries; provide demos and support; monitor reliability; generate customer-requested governance evidence; prevent abuse; comply with law; and send administrative or permitted marketing communications.
 
-## Security
+## 4. EU/UK legal bases
 
-We apply reasonable technical and organizational safeguards. See our [Security Overview](/docs/security/).
+Depending on context, Cerbi may rely on contract, legitimate interests, consent, legal obligation, or customer instructions where Cerbi acts as processor or service provider.
 
-## Contact
+## 5. Cookies and analytics
+
+Cerbi may use cookies, local storage, pixels, and similar technologies for site operation, security, preferences, analytics, and product improvement. We may use Google Analytics / Google Tag Manager and Amplitude. Where required by law, non-essential analytics should be used only with consent. See our [Cookie Policy](/docs/cookies/).
+
+## 6. Sharing
+
+We do not sell personal information. We may disclose information to service providers and subprocessors, marketplace providers, professional advisors, authorities when required by law, or successors in a business transaction. See our [Subprocessors and Service Providers](/docs/subprocessors/).
+
+## 7. International transfers
+
+Cerbi is based in the United States. Information may be processed in the United States and other countries where Cerbi or our service providers operate. Where required, we use appropriate safeguards for international transfers.
+
+## 8. Retention
+
+We retain information only as long as reasonably necessary for the purposes described in this Privacy Policy, including to provide services, comply with legal obligations, resolve disputes, enforce agreements, maintain security, and support audit or business records.
+
+## 9. Security
+
+We use reasonable technical and organizational safeguards intended to protect information. Cerbi products are designed to support source-side data minimization, redaction, blocking, policy versioning, audit records, and evidence exports. See our [Security Overview](/docs/security/).
+
+## 10. Rights and choices
+
+Depending on your location and relationship with Cerbi, you may have rights to access, correct, delete, restrict, object to processing, withdraw consent, request portability, opt out of marketing, or lodge a complaint with a regulator. To exercise rights, contact **hello@cerbi.io**.
+
+## 11. California privacy notice
+
+We do not sell personal information. We do not knowingly share personal information for cross-context behavioral advertising in a way that would require a sale/share opt-out unless otherwise disclosed through cookie or consent controls. California residents may have rights to know/access, delete, correct, limit certain uses of sensitive personal information, and opt out of sale/share where applicable.
+
+## 12. Sensitive data and children
+
+Customers should not intentionally submit sensitive personal information, credentials, secrets, payment card data, protected health information, or other regulated data to Cerbi or downstream logs unless they have appropriate rights, controls, agreements, and safeguards in place. Cerbi websites and services are not directed to children under 13.
+
+## 13. Contact
 
 Cerbi LLC  
 7901 4TH ST N STE 300  
 St. Petersburg, FL 33702  
-hello@cerbi.io
+United States  
+Email: **hello@cerbi.io**

--- a/public_documents/security.md
+++ b/public_documents/security.md
@@ -1,31 +1,59 @@
 ---
 title: "Security Overview"
-description: "How Cerbi approaches security, privacy, and safe telemetry."
+description: "How Cerbi approaches security, privacy, source-side logging governance, and evidence generation."
 permalink: /docs/security/
 layout: default
+last_updated: 2026-07-06
 ---
 
 # Security Overview
 
-**Architecture**
-- Source-governed telemetry: build-time analyzer + runtime validator
-- Encryption via `IEncryption` implementations: AES, Base64, or NoOp
-- File fallback with rotation for resilient logging
+**Last updated:** 2026-07-06
 
-**Data minimization**
-- PII redaction controlled by policy
-- Relax mode preserves signals while tagging violations
-- Stable schemas reduce accidental leakage
+Cerbi products are designed to help teams reduce logging data risk by applying governance before log events reach downstream observability, SIEM, analytics, or storage systems.
 
-**Access control (CerbiShield, beta)**
-- Role-based access control (RBAC)
-- Profile versioning with audit history and rollbacks
+This page summarizes Cerbi's security posture and product security model. It is not a compliance certification or legal opinion.
 
-**Handling sensitive data**
-- Recommended: exclude PII from logs entirely
-- If business-necessary, mask at source per policy and document justification
+## Source-side logging governance
 
-**Reporting**
-- Please report vulnerabilities to **security@cerbi.io**
-- Include reproduction steps, expected vs. actual behavior, and impact
-- We will acknowledge receipt and follow up with status updates
+Cerbi's core security model is source-side governance:
+
+- Evaluate log events before they leave the application boundary.
+- Detect sensitive, forbidden, missing, or malformed fields.
+- Redact or block risky values according to policy.
+- Preserve evidence of which policy evaluated an event.
+- Keep existing log routing, SIEM, APM, and observability tools in place.
+
+Cerbi does not replace Splunk, Datadog, Azure Monitor, OpenTelemetry, SIEM platforms, or application logging frameworks. It adds governance before data reaches those systems.
+
+## Data minimization by design
+
+Cerbi encourages teams to avoid putting personal data, credentials, secrets, payment data, protected health information, or other sensitive data into logs.
+
+Where logging sensitive operational signals is business-necessary, Cerbi can help teams classify, redact, block, review, and document fields and exceptions.
+
+## Policy versioning and evidence
+
+CerbiShield can support governance profile IDs, versions, hashes, decisions, enforcement actions, exception details, deployment history, and audit history. These records are intended to support engineering review, security review, audit preparation, and CISO reporting.
+
+## Evidence Center and manifest hash
+
+CerbiShield Evidence Center packages governance, scoring, audit, deployment, violation, and rule records into review-friendly exports. Exports may include CSV and JSON manifest records with a manifest hash.
+
+## Access control and customer environments
+
+CerbiShield may include role-based access controls, tenant-aware APIs, policy management, and customer-controlled deployment patterns. Depending on deployment model, components may run in a customer cloud tenant or customer-controlled environment.
+
+Customers remain responsible for configuring identity, access controls, network controls, logging destinations, retention, and downstream data systems.
+
+## Vulnerability reporting
+
+Please report suspected vulnerabilities to **security@cerbi.io**.
+
+Include the affected product or package, version or commit if known, reproduction steps, expected and actual behavior, potential impact, and whether the issue may expose customer data.
+
+## Compliance-safe positioning
+
+CerbiShield provides source-side logging governance and evidence that can support audit preparation and control review.
+
+Cerbi does not provide legal advice and does not certify DORA, GDPR, CCPA/CPRA, HIPAA, SOC 2, or other regulatory compliance. Customers remain responsible for their own compliance programs, system configuration, policies, notices, retention, and legal obligations.


### PR DESCRIPTION
## Summary

Adds the actual website paperwork/docs for Cerbi.io instead of tracking the work as an issue.

### Added

- `docs/cookies.md` — Cookie Policy
- `docs/subprocessors.md` — Subprocessors and Service Providers
- `docs/dpa.md` — DPA availability page
- `docs/trust.md` — Trust and compliance-safe positioning

### Updated

- `docs/privacy.md` — expanded enterprise privacy policy
- `docs/security.md` — expanded security overview for source-side governance, Evidence Center, manifest hash, and compliance-safe positioning
- `public_documents/privacy.md` — synced public privacy summary
- `public_documents/security.md` — synced public security summary
- `downloads/Cerbi-Privacy-Policy.md` — updated downloadable privacy policy
- `downloads/Cerbi-Terms-of-Service.md` — cleaned contact formatting and added compliance-safe disclaimer

## Positioning

This paperwork uses safe language:

- DORA-aligned evidence
- supports audit preparation
- supports GDPR-style accountability and data minimization
- not legal advice
- not compliance certification

It avoids overclaims such as:

- DORA compliant
- GDPR compliant
- EU compliant
- certifies compliance
- guarantees compliance

## Linking status

The docs are cross-linked from the new Trust/Security/Privacy pages and use site permalinks such as `/docs/privacy/`, `/docs/cookies/`, `/docs/subprocessors/`, `/docs/dpa/`, `/docs/trust/`, and `/docs/security/`.

The homepage footer/navigation is **not yet wired** to these new pages in this PR. That should be a follow-up site-wiring change, along with the cookie-consent banner and deferred GA4/Amplitude loading.

## Notes

This PR adds the paperwork only. It does not implement the technical cookie-consent banner or defer GA4/Amplitude loading. That should be a separate implementation change.

## Validation

- Compared branch against `main`: 10 files changed
- Added/updated docs only
- No application code changes